### PR TITLE
mammon.channel: disallow joining a channel multiple times

### DIFF
--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -130,8 +130,9 @@ def m_JOIN(cli, ev_msg):
         if not validate_chan(chan):
             cli.dump_numeric('479', [chan, 'Illegal channel name'])
             return
-
         ch = cli.ctx.chmgr.get(chan, create=True)
+        if ch.has_member(cli):
+            continue
         if not ch.authorize(cli, ev_msg):
             continue
 


### PR DESCRIPTION
Currently, if you execute the `JOIN` command on a single channel multiple times, you'll be added to the list of users in the channel multiple times, and the user ends up receiving duplicate messages each time an event, like a join or message, occurs in the channel.

This prevents a user from joining a channel multiple times, and just ignores any trailing joins. This seems like standard behaviour for other IRCds; no numeric seems like it has been delegated for this event (443: `ERR_USERONCHANNEL` seems close but it asks for the user affected as a parameter, and it's used for when a user `INVITE`s another user that's already in the target channel).

Many other IRCds do not reply with any message, but instead seem to ignore the errant `JOIN`, so that's what is implemented here.
