### PR TITLE
Fix --config command-line option

### DIFF
--- a/mammon/server.py
+++ b/mammon/server.py
@@ -103,7 +103,7 @@ Options:
             self.usage()
         if '--config' in sys.argv:
             try:
-                self.config = sys.argv[sys.argv.index('--config') + 1]
+                self.config_name = sys.argv[sys.argv.index('--config') + 1]
             except IndexError:
                 print('mammon: error: no parameter provided for --config')
                 exit(1)


### PR DESCRIPTION
Just fixes a small bug where the file given in the `--config` command-line option isn't properly used.
