### PR TITLE
Add OPER command, including hashed passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ In the meantime the dependencies are:
  * Python 3.4 (or Python 3.3+ with Tulip, or PyPy SVN with Tulip),
  * `ircmatch` library,
  * `ircreactor` library,
- * `PyYAML` library.
+ * `PyYAML` library,
+ * `passlib` library (if password hashing is used).
 
 ## contact
 

--- a/mammon/hashing.py
+++ b/mammon/hashing.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+class HashHandler:
+    valid_schemes = ('sha512_crypt', 'pbkdf2_sha512')
+
+    def __init__(self):
+        try:
+            from passlib.context import CryptContext
+            self.enabled = True
+        except ImportError:
+            self.enabled = False
+
+        if self.enabled:
+            self.context = CryptContext(schemes=self.valid_schemes)
+
+    def encrypt(self, *args, **kwargs):
+        return self.context.encrypt(*args, **kwargs)
+
+    def verify(self, password, hash):
+        is_valid = False
+
+        if self.enabled:
+            is_valid = self.context.verify(password, hash)
+
+        del password
+        return is_valid

--- a/mammon/hashing.py
+++ b/mammon/hashing.py
@@ -16,6 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 class HashHandler:
+    default_scheme = 'sha512_crypt'
     valid_schemes = ('sha512_crypt', 'pbkdf2_sha512')
 
     def __init__(self):

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -24,6 +24,7 @@ def get_context():
     return running_context
 
 from .config import ConfigHandler
+from .hashing import HashHandler
 from .utility import CaseInsensitiveDict, ExpiringDict
 from .channel import ChannelManager
 from .capability import caplist
@@ -50,6 +51,9 @@ class ServerContext(object):
 
         self.chmgr = ChannelManager(self)
         self.client_history = ExpiringDict(max_len=1024, max_age_seconds=86400)
+
+        # must be done before handling command line
+        self.hashing = HashHandler()
 
         self.handle_command_line()
 
@@ -92,15 +96,47 @@ class ServerContext(object):
 A useless ircd.
 
 Options:
-   --help              - This screen.
-   --debug             - Enable debug verbosity
-   --nofork            - Do not fork into background
-   --config config     - A JSON configuration file to parse""".format(cmd))
+   --help                         - This screen.
+   --debug                        - Enable debug verbosity
+   --nofork                       - Do not fork into background
+   --config config                - A JSON configuration file to parse
+   --list-hashes                  - List the supported hashes for passwords
+   --mkpasswd <hash> <password>   - Return hashed password, to put into config files""".format(cmd))
+        exit(1)
+
+    def list_hashes(self):
+        print('Valid hashing algorithms:', ', '.join(self.hashing.valid_schemes))
+        exit(1)
+
+    def mkpasswd(self):
+        try:
+            i = sys.argv.index('--mkpasswd')
+            scheme = sys.argv[i + 1]
+            text = sys.argv[i + 2]
+        except IndexError:
+            print('mammon: error: hash and/or password missing provided for --mkpasswd')
+            exit(1)
+
+        if not self.hashing.enabled:
+            print('mammon: error: hashing is not enabled, try:  pip3 install passlib')
+            exit(1)
+
+        if scheme not in self.hashing.valid_schemes:
+            print('mammon: error: hash is not supported, valid hashes are:', ', '.join(self.hashing.valid_schemes))
+            exit(1)
+
+        hash = self.hashing.encrypt(text, scheme=scheme)
+        print(hash)
+
         exit(1)
 
     def handle_command_line(self):
         if '--help' in sys.argv:
             self.usage()
+        if '--list-hashes' in sys.argv:
+            self.list_hashes()
+        if '--mkpasswd' in sys.argv:
+            self.mkpasswd()
         if '--config' in sys.argv:
             try:
                 self.config_name = sys.argv[sys.argv.index('--config') + 1]

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -35,6 +35,7 @@ import sys
 import time
 import os
 import importlib
+from getpass import getpass
 
 class ServerContext(object):
     options = []
@@ -96,12 +97,12 @@ class ServerContext(object):
 A useless ircd.
 
 Options:
-   --help                         - This screen.
-   --debug                        - Enable debug verbosity
-   --nofork                       - Do not fork into background
-   --config config                - A JSON configuration file to parse
-   --list-hashes                  - List the supported hashes for passwords
-   --mkpasswd <hash> <password>   - Return hashed password, to put into config files""".format(cmd))
+   --help              - This screen.
+   --debug             - Enable debug verbosity
+   --nofork            - Do not fork into background
+   --config config     - A JSON configuration file to parse
+   --list-hashes       - List the supported hashes for passwords
+   --mkpasswd          - Return hashed password, to put into config files""".format(cmd))
         exit(1)
 
     def list_hashes(self):
@@ -109,23 +110,27 @@ Options:
         exit(1)
 
     def mkpasswd(self):
-        try:
-            i = sys.argv.index('--mkpasswd')
-            scheme = sys.argv[i + 1]
-            text = sys.argv[i + 2]
-        except IndexError:
-            print('mammon: error: hash and/or password missing provided for --mkpasswd')
-            exit(1)
-
         if not self.hashing.enabled:
             print('mammon: error: hashing is not enabled, try:  pip3 install passlib')
             exit(1)
 
-        if scheme not in self.hashing.valid_schemes:
-            print('mammon: error: hash is not supported, valid hashes are:', ', '.join(self.hashing.valid_schemes))
-            exit(1)
+        print('Valid hashing algorithms:', ', '.join(self.hashing.valid_schemes))
 
-        hash = self.hashing.encrypt(text, scheme=scheme)
+        scheme = 'invalid'
+        prompt = 'Hashing algorithm [{default}]: '.format(default=self.hashing.default_scheme)
+        while scheme != '' and scheme not in self.hashing.valid_schemes:
+            scheme = input(prompt)
+        if scheme == '':
+            scheme = self.hashing.default_scheme
+
+        password = ''
+        prompt = 'Password: '
+        while password.strip() == '':
+            password = getpass(prompt)
+
+        print('')
+
+        hash = self.hashing.encrypt(password, scheme=scheme)
         print(hash)
 
         exit(1)

--- a/mammond.yml
+++ b/mammond.yml
@@ -32,11 +32,23 @@ logs:
 
 # The IRC Operators
 opers:
+  # name - the name of the operator
   "nobody":
-    # password - what the oper uses to login
+    # password - the plaintext oper password
     password: "nothing"
 
-    # host - if defined, where the oper must connect from
+    # host - if defined, the host the oper must connect from
+    host: "127.0.0.1"
+
+  # name - the name of the operator
+  "somebody":
+    # password - the hashed oper password
+    password: "$6$rounds=100000$KkEHFBhWHV3BHCCS$YuOdlikJHdeIv2YpwvyLAtYCslDlsnUUnrfeKJiBh4SeVhkSU6pQqHWWDjr6lnalkkf1KLDD1wgSQH5AObILQ1"
+
+    # hash - the hashing algorithm to use
+    hash: "sha512_crypt"
+
+    # host - if defined, the host the oper must connect from
     host: "127.0.0.1"
 
 # The extensions section is a list of extension modules to load.

--- a/mammond.yml
+++ b/mammond.yml
@@ -37,8 +37,8 @@ opers:
     # password - the plaintext oper password
     password: "nothing"
 
-    # host - if defined, the host the oper must connect from
-    host: "127.0.0.1"
+    # hostmask - if defined, the hostmask the oper must connect from
+    hostmask: "*@localhost"
 
   # name - the name of the operator
   "somebody":
@@ -49,8 +49,8 @@ opers:
     # hash - the hashing algorithm to use
     hash: "sha512_crypt"
 
-    # host - if defined, the host the oper must connect from
-    host: "127.0.0.1"
+    # hostmask - if defined, the hostmask the oper must connect from
+    hostmask: "somebody!*@localhost"
 
 # The extensions section is a list of extension modules to load.
 extensions:

--- a/mammond.yml
+++ b/mammond.yml
@@ -43,6 +43,7 @@ opers:
   # name - the name of the operator
   "somebody":
     # password - the hashed oper password
+    # created by:  mammond --mkpasswd
     password: "$6$rounds=100000$KkEHFBhWHV3BHCCS$YuOdlikJHdeIv2YpwvyLAtYCslDlsnUUnrfeKJiBh4SeVhkSU6pQqHWWDjr6lnalkkf1KLDD1wgSQH5AObILQ1"
 
     # hash - the hashing algorithm to use

--- a/mammond.yml
+++ b/mammond.yml
@@ -30,6 +30,15 @@ logs:
      "level": "debug"
   }
 
+# The IRC Operators
+opers:
+  "nobody":
+    # password - what the oper uses to login
+    password: "nothing"
+
+    # host - if defined, where the oper must connect from
+    host: "127.0.0.1"
+
 # The extensions section is a list of extension modules to load.
 extensions:
 - mammon.ext.rfc1459.42


### PR DESCRIPTION
Adds IRC Opers, including password hashing.

If `passlib` is not installed hashing is simply disabled, and an error message is printed if someone tries to `OPER` with an account with a hashed password.

The `hash: "sha512_crypt"` variable in the config is not strictly required for the hashing to work, but I figure if we want to add bcrypt or other hashes that require different python modules to be installed, it helps a whole lot with diagnosing problems where someone can't oper up, but the issue is just that the required hashing algorithm is not supported/installed. (the way we check supported schemes, this already works)
