### PR TITLE
Remove debug code from OPER command, load roles properly and show in whois

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -196,7 +196,7 @@ class ClientProtocol(asyncio.Protocol):
             st += 'G'
         else:
             st += 'H'
-        if self.operator:
+        if self.props.get('special:oper', False):
             st += '*'
         return st
 

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -62,7 +62,7 @@ class ClientProtocol(asyncio.Protocol):
         self.servername = self.ctx.conf.name
 
         self.away_message = str()
-        self.operator = None              # XXX - update when operator objects are implemented
+        self._role_name = None
         self.account = None               # XXX - update if needed when account objects are implemented
 
         self.connected = True
@@ -77,6 +77,14 @@ class ClientProtocol(asyncio.Protocol):
 
     def update_idle(self):
         self.last_event_ts = self.ctx.current_ts
+
+    @property
+    def role(self):
+        return self.ctx.roles.get(self._role_name)
+
+    @role.setter
+    def role(self, value):
+        self._role_name = value
 
     @property
     def idle_time(self):

--- a/mammon/config.py
+++ b/mammon/config.py
@@ -19,6 +19,7 @@ import yaml
 import asyncio
 import logging
 from .client import ClientProtocol
+from .roles import Role
 
 class ConfigHandler(object):
     config_st = {}
@@ -46,3 +47,8 @@ class ConfigHandler(object):
             self.ctx.logger.info('opening listener at {0}:{1} [{2}]'.format(l['host'], l['port'], proto))
             lstn = self.ctx.eventloop.create_server(self.listener_protos[proto], l['host'], l['port'])
             self.ctx.listeners.append(lstn)
+
+        roles = {}
+        for k, v in self.roles.items():
+            roles[k] = Role(self.ctx, k, **v)
+        self.ctx.roles = roles

--- a/mammon/config.py
+++ b/mammon/config.py
@@ -21,6 +21,13 @@ import logging
 from .client import ClientProtocol
 from .roles import Role
 
+def load_extended_roles(ctx, k, roles, roles_extending):
+    for kk, vv in roles_extending.get(k, {}).items():
+        roles[kk] = Role(ctx, kk, roles=roles, **vv)
+        roles = load_extended_roles(ctx, kk, roles, roles_extending)
+
+    return roles
+
 class ConfigHandler(object):
     config_st = {}
     ctx = None
@@ -49,6 +56,21 @@ class ConfigHandler(object):
             self.ctx.listeners.append(lstn)
 
         roles = {}
+        roles_extending = {
+            None: {},
+        }
+
+        # get base list of which roles extend from which
         for k, v in self.roles.items():
-            roles[k] = Role(self.ctx, k, **v)
+            extends = v.get('extends', None)
+            if extends not in roles_extending:
+                roles_extending[extends] = {}
+            roles_extending[extends][k] = v
+
+        # load base roles, then roles that extend those
+        base_roles = roles_extending[None]
+        for k, v in base_roles.items():
+            roles[k] = Role(self.ctx, k, roles=roles, **v)
+            roles = load_extended_roles(self.ctx, k, roles, roles_extending)
+
         self.ctx.roles = roles

--- a/mammon/events.py
+++ b/mammon/events.py
@@ -300,7 +300,7 @@ def m_WHO(cli, ev_msg):
         oper_query = 'o' in ev_msg['params'][1]
 
     def do_single_who(cli, tparam, target, status=None):
-        if oper_query and not target.operator:
+        if oper_query and not target.props.get('special:oper', False):
             return
         if not status:
             status = target.status

--- a/mammon/events.py
+++ b/mammon/events.py
@@ -335,7 +335,7 @@ def m_WHOIS(cli, ev_msg):
         cli.dump_numeric('319', [cli_tg.nickname, ' '.join([x.channel_name for x in channels]) + ' '])
     cli.dump_numeric('312', [cli_tg.nickname, cli.ctx.conf.name, cli.ctx.conf.description])
     if cli_tg.role:
-        cli.dump_numeric('313', [cli_tg.nickname, cli_tg.role.whois_format.format(role=cli_tg.role.whois)])
+        cli.dump_numeric('313', [cli_tg.nickname, cli_tg.role.whois_line])
     if cli_tg.account:
         cli.dump_numeric('330', [cli_tg.nickname, cli_tg.account.name, 'is logged in as'])
     cli.dump_numeric('317', [cli_tg.nickname, cli_tg.idle_time, cli_tg.registration_ts, 'seconds idle, signon time'])

--- a/mammon/roles.py
+++ b/mammon/roles.py
@@ -19,7 +19,7 @@ default_whois_format = 'is a {role}.'
 default_vowel_whois_format = 'is an {role}.'
 
 class Role:
-    def __init__(self, ctx, name, extends=None, **kwargs):
+    def __init__(self, ctx, name, roles=None, extends=None, **kwargs):
         self.ctx = ctx
         self.name = name
 
@@ -43,8 +43,12 @@ class Role:
 
         self.whois_line = self.whois_format.format(role=self.whois)
 
-        if extends and extends in self.ctx.roles:
-            for capability in self.ctx.roles.get(extends).capabilities:
+        # extending roles
+        if roles is None:
+            roles = self.ctx.roles
+
+        if extends and extends in roles:
+            for capability in roles.get(extends).capabilities:
                 if capability not in self.capabilities:
                     self.capabilities.append(capability)
         elif extends:

--- a/mammon/roles.py
+++ b/mammon/roles.py
@@ -41,6 +41,8 @@ class Role:
                 elif character.isalpha():
                     break
 
+        self.whois_line = self.whois_format.format(role=self.whois)
+
         if extends and extends in self.ctx.roles:
             for capability in self.ctx.roles.get(extends).capabilities:
                 if capability not in self.capabilities:

--- a/mammon/roles.py
+++ b/mammon/roles.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+default_whois_format = 'is a {role}.'
+default_vowel_whois_format = 'is an {role}.'
+
+class Role:
+    def __init__(self, ctx, name, extends=None, **kwargs):
+        self.ctx = ctx
+        self.name = name
+
+        # defaults
+        self.capabilities = []
+        self.whois = ''
+        self.whois_format = None
+
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+        # automatically choose a/an for whois message
+        if self.whois_format is None:
+            self.whois_format = default_whois_format
+            for character in self.whois:
+                if character.isalpha() and character.lower() in ['a', 'e', 'i', 'o', 'u']:
+                    self.whois_format = default_vowel_whois_format
+                    break
+                elif character.isalpha():
+                    break
+
+        if extends and extends in self.ctx.roles:
+            for capability in self.ctx.roles.get(extends).capabilities:
+                if capability not in self.capabilities:
+                    self.capabilities.append(capability)
+        elif extends:
+            print('mammon: error: error in role', name, '- extending role', extends, 'does not exist')

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -39,6 +39,7 @@ from getpass import getpass
 
 class ServerContext(object):
     options = []
+    roles = []
     clients = CaseInsensitiveDict()
     channels = CaseInsensitiveDict()
     listeners = []


### PR DESCRIPTION
Just removes a silly debug `try: except` I left in the OPER command, and sets roles properly for clients.

We use the `@property` method instead of just assigning a `mammon.roles.Role` object directly to `client.role` so that this updates permissions and such when we rehash the server config later down the line.

**edit:** This also adds `extends` to the role dictionaries, so you can extend a role from another. This adds the capabilities from the parent role to the capabilities of that role.

eg:

``` yaml
# Roles define the capabilities an oper may have, as well as role-specific
# metadata.
roles:
  "admin":
    capabilities:
      - oper:kill
      - oper:routing
    whois: "IRC Administrator"

  "server_admin":
    extends: "admin"
    capabilities:
      - oper:shutdown
      - oper:rehash
    whois: "Server Administrator"
```
