### PR TITLE
Add KILL command

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -202,8 +202,8 @@ class ClientProtocol(asyncio.Protocol):
 
     def kill(self, source, reason):
         m = RFC1459Message.from_data('KILL', source=source.hostmask, params=[self.nickname, reason])
-        self.sendto_common_peers(m)
-        self.exit()
+        self.dump_message(m)
+        self.quit('Killed ({source} ({reason}))'.format(source=source.nickname, reason=reason))
 
     def quit(self, message):
         m = RFC1459Message.from_data('QUIT', source=self.hostmask, params=[message])


### PR DESCRIPTION
Just adds the KILL command, changing `client.exit()` to exit without any message, so the code should either use `client.quit` or `client.kill` instead (I've already modified existing code to do so, just a note for any code in the future).
