### PR TITLE
Add some new roles/capabilities, document capabilities, etc

### DIFF
--- a/mammon/events.py
+++ b/mammon/events.py
@@ -102,7 +102,7 @@ def m_KILL(cli, ev_msg):
     target, reason = ev_msg['params'][:2]
 
     # XXX - when we have multiple servers, we will need to check local kill vs remote kill
-    if 'oper:kill' not in cli.role.capabilities:
+    if 'oper:local_kill' not in cli.role.capabilities:
         cli.dump_numeric('481', ['Permission Denied'])
         return
 

--- a/mammon/roles.py
+++ b/mammon/roles.py
@@ -25,7 +25,7 @@ class Role:
 
         # defaults
         self.capabilities = []
-        self.whois = ''
+        self.title = ''
         self.whois_format = None
 
         for k, v in kwargs.items():
@@ -34,14 +34,14 @@ class Role:
         # automatically choose a/an for whois message
         if self.whois_format is None:
             self.whois_format = default_whois_format
-            for character in self.whois:
+            for character in self.title:
                 if character.isalpha() and character.lower() in ['a', 'e', 'i', 'o', 'u']:
                     self.whois_format = default_vowel_whois_format
                     break
                 elif character.isalpha():
                     break
 
-        self.whois_line = self.whois_format.format(role=self.whois)
+        self.whois_line = self.whois_format.format(role=self.title)
 
         # extending roles
         if roles is None:

--- a/mammond.yml
+++ b/mammond.yml
@@ -37,8 +37,8 @@ logs:
 # metadata.
 
   # mammon capability names:
-  #   oper:local_kill    allows local users to be /KILL'd
-  #   oper:global_kill   allows local and remote users to be /KILL'd
+  #   oper:local_kill    allows /KILLing local users
+  #   oper:global_kill   allows /KILLing local and remote users
   #   oper:routing       allows remote SQUIT and CONNECT
   #   oper:kline         allows KLINE and DLINE
   #   oper:unkline       allows UNKLINE and UNDLINE

--- a/mammond.yml
+++ b/mammond.yml
@@ -16,9 +16,11 @@ server:
   motd:
   - "This is mammond's default motd.  You can change it in mammond.yml."
 
+
 # The listeners object is a list of listeners.
 listeners:
 - {"host": "0.0.0.0", "port": 6667, "ssl": false}
+
 
 # The logs section is a list of logs.
 logs:
@@ -30,18 +32,68 @@ logs:
      "level": "debug"
   }
 
+
 # Roles define the capabilities an oper may have, as well as role-specific
 # metadata.
+
+  # mammon capability names:
+  #   oper:local_kill    allows local users to be /KILL'd
+  #   oper:global_kill   allows local and remote users to be /KILL'd
+  #   oper:routing       allows remote SQUIT and CONNECT
+  #   oper:kline         allows KLINE and DLINE
+  #   oper:unkline       allows UNKLINE and UNDLINE
+  #   oper:remote_ban    allows remote klines
+  #   oper:rehash        allows REHASH of server config
+  #   oper:die           allows DIE and RESTART
+
 roles:
   # name - the name of the privilege set
-  "admin":
+  "local_op":
     # capabilities - a list of qualified capability names
     capabilities:
-      - oper:kill
+      - oper:local_kill
+      - oper:kline
+      - oper:unkline
+
+    # title - metadata identifying the specific role
+    title: "IRC Operator"
+
+  # name - the name of the privilege set
+  "global_op":
+    # extends - inherets this role's capabilities
+    extends: "local_op"
+
+    # capabilities - a list of qualified capability names
+    capabilities:
+      - oper:global_kill
+      - oper:remote_ban
+
+    # title - metadata identifying the specific role
+    title: "IRC Operator"
+
+  # name - the name of the privilege set
+  "network_admin":
+    # capabilities - a list of qualified capability names
+    capabilities:
+      - oper:global_kill
       - oper:routing
 
-    # whois - metadata identifying the specific role
-    whois: "IRC Administrator"
+    # title - metadata identifying the specific role
+    title: "Network Administrator"
+
+  # name - the name of the privilege set
+  "server_admin":
+    # extends - inherets this role's capabilities
+    extends: "local_op"
+
+    # capabilities - a list of qualified capability names
+    capabilities:
+      - oper:rehash
+      - oper:die
+
+    # title - metadata identifying the specific role
+    title: "Server Administrator"
+
 
 # Operator credentials allow a user to transition from a typical user role
 # to a privileged role.
@@ -71,6 +123,7 @@ opers:
 
     # role - the role that the credentials allow transition to
     role: "admin"
+
 
 # The extensions section is a list of extension modules to load.
 extensions:


### PR DESCRIPTION
First thing is that this brings our capability names more in-line with charybdis.

The only thing I'm a bit weirded by in the capability names is the presence of `kline / unkline / remote_ban`. I was thinking of maybe `local_ban / local_unban` to replace `kline / unkline`, since one set of kline-related capabilities using the term `kline` and the other using `ban` seems a bit wrong (mixing levels of abstraction).

We also can't support the new `global_*` capabilities in code yet as we don't have server linking, but I think it's best to prepare for the future and just design towards that now.

I renamed the `whois` var to `title`, since I can see possibly reusing it later on in non-whois related places as well, and I think this name makes more sense.

I also changed the roles so we have four: `local_op`, `global_op`, `network_admin`, `server_admin`. Again, two of those hold no real purpose right now, but when we get s2s implemented I think that's a decent starting list.

And I added another blank line between config sections, just separates things more clearly - especially when we're documenting things like the capability names as we are.

Any issues, or other capabilities and roles you'd like thrown in, lemme know!
