### PR TITLE
Implement SSL Listeners

### DIFF
--- a/mammon/config.py
+++ b/mammon/config.py
@@ -76,6 +76,10 @@ class ConfigHandler(object):
 
                 # disable compression because of CRIME attack
                 context.options |= ssl.OP_NO_COMPRESSION
+
+                # XXX - we want to move SSL out-of-process, similar to how charybdis does it,
+                #   but for now, just a warning
+                print('mammon: note: SSL support is not yet optimized and may cause slowdowns in your server')
             else:
                 context = None
 

--- a/mammon/config.py
+++ b/mammon/config.py
@@ -69,6 +69,13 @@ class ConfigHandler(object):
                     continue
 
                 context.load_cert_chain(certfile, keyfile=keyfile)
+
+                # disable old protocols
+                context.options |= ssl.OP_NO_SSLv2
+                context.options |= ssl.OP_NO_SSLv3
+
+                # disable compression because of CRIME attack
+                context.options |= ssl.OP_NO_COMPRESSION
             else:
                 context = None
 


### PR DESCRIPTION
Lets you enable and use SSL listeners, with supplied key/cert files.

`ssl.PROTOCOL_SSLv23` just selects the highest available SSL/TLS protocol that both the client and server support, from SSLv2 to TLSv1.2. I haven't done much with SSL/TLS, but that should be what we want?

(table of the various protocols supported by Python's SSL library just under [this heading](https://docs.python.org/3/library/ssl.html#ssl.wrap_socket))
