### PR TITLE
implement channel modes, fix errors with asyncio and logging

### DIFF
--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -17,7 +17,9 @@
 
 from ircreactor.envelope import RFC1459Message
 from .utility import validate_chan, CaseInsensitiveDict
-from .property import member_property_items
+from .property import member_property_items, channel_property_items, channel_flag_items
+import copy
+from ircmatch import match
 
 class ChannelManager(object):
     def __init__(self, ctx):
@@ -43,7 +45,7 @@ class ChannelMembership(object):
     def name(self):
         pstr = str()
         for prop, flag in member_property_items.items():
-            if prop in self.props:
+            if self.props.get(prop, False):
                 pstr += flag
         pstr += self.client.nickname
         return pstr
@@ -52,7 +54,7 @@ class ChannelMembership(object):
     def who_status(self):
         pstr = self.client.status
         for prop, flag in member_property_items.items():
-            if prop in self.props:
+            if self.props.get(prop, False):
                 pstr += flag
         return pstr
 
@@ -60,7 +62,7 @@ class ChannelMembership(object):
     def channel_name(self):
         pstr = str()
         for prop, flag in member_property_items.items():
-            if prop in self.props:
+            if self.props.get(prop, False):
                 pstr += flag
         pstr += self.channel.name
         return pstr
@@ -73,19 +75,40 @@ class Channel(object):
         self.topic_setter = str()
         self.topic_ts = 0
         self.props = CaseInsensitiveDict()
+        self.props_ts = 0
         self.user_set_metadata = []
         self.metadata = CaseInsensitiveDict()
 
     def authorize(self, cli, ev_msg):
-        if 'key' in self.props and self.props['key'] != ev_msg['params'][1]:
-            cli.dump_numeric('474', [self.name, 'Cannot join channel (+k) - bad key'])
+        if 'key' in self.props and (len(ev_msg['params']) < 2 or self.props['key'] != ev_msg['params'][1]):
+            cli.dump_numeric('475', [self.name, 'Cannot join channel (+k) - bad key'])
+            return False
+        if 'exempt' in self.props:
+            for e in self.props['exempt']:
+                if match(0, e, cli.hostmask):
+                    return True
+        if 'ban' in self.props:
+            for b in self.props['ban']:
+                if match(0, b, cli.hostmask):
+                    cli.dump_numeric('474', [self.name, 'You are banned.'])
+                    return False
+        if 'invite' in self.props and 'invite-exemption' in self.props:
+            for i in self.props['invite-exemption']:
+                if match(0, i, cli.hostmask):
+                    return True
+                # XXX - /invite command
             return False
         return True
 
     def join(self, client):
+        has_members = len(self.members) != 0
         m = ChannelMembership(client, self)
         self.members.append(m)
         client.channels.append(m)
+        if not has_members:
+            m.props['op'] = True
+            msg = RFC1459Message.from_data('MODE', source=client.hostmask, params=[self.name, "+o", client.nickname])
+            self.dump_message(msg)
 
     def part(self, client):
         for m in filter(lambda x: x.client == client, self.members):
@@ -97,16 +120,26 @@ class Channel(object):
         matches = tuple(filter(lambda x: x.client == client, self.members))
         return len(matches) > 0
 
-    def can_send(self, client):
-        is_member = self.has_member(client)
-        if 'allow-external' not in self.props and not is_member:
-            return False
+    def get_member(self, client):
+        matches = tuple(filter(lambda x: x.client == client, self.members))
+        return len(matches) > 0 and matches[0]
 
-        # XXX - access checking
+    def find_member(self, nickname):
+        matches = tuple(filter(lambda x: x.client.nickname == nickname, self.members))
+        return len(matches) > 0 and matches[0]
+
+    def can_send(self, client):
+        member = self.get_member(client)
+        if not self.props.get('allow-external', False) and not member:
+            return False
+        if self.props.get('moderated', False):
+            if member.props.get('op', False) or member.props.get('voice', False):
+                return True
+            return False
         return True
 
     def can_display(self, client):
-        if 'secret' not in self.props:
+        if self.props.get('secret', False):
             return True
         return self.has_member(client)
 
@@ -114,6 +147,141 @@ class Channel(object):
         if not exclusion_list:
             exclusion_list = list()
         [m.client.dump_message(msg) for m in self.members if m.client not in exclusion_list]
+
+    def set_legacy_modes(self, client, in_str, args):
+
+        before = copy.deepcopy(self.props)
+        before_users = copy.deepcopy({member.client.nickname: member.props for member in self.members})
+
+        mod = False
+        for i in in_str:
+            if i == '+':
+                mod = True
+            elif i == '-':
+                mod = False
+            else:
+                if i not in channel_flag_items:
+                    client.dump_numeric('472', [i, 'is an unknown mode char to me'])
+                    continue
+                prop = channel_flag_items[i]
+                if prop == 'ban' or prop == 'invite-exemption' or prop == 'exemption' or prop == 'quiet':
+                    if prop not in self.props:
+                        self.props[prop] = CaseInsensitiveDict()
+                    if len(args) == 0:
+                        for user, info in self.props[prop].items():
+                            client.dump_numeric('367', [self.name, user, info[0], info[1]])
+                        client.dump_numeric('368', [self.name, 'End of Channel '+prop.title()+' List'])
+                        continue
+                    arg = args.pop(0)
+                    if mod == False and arg in self.props[prop]:
+                        del(self.props[prop][arg])
+                    if mod == True:
+                        self.props[prop][arg] = (client.hostmask, client.ctx.current_ts)
+                    continue
+                if prop == 'key' or prop == 'limit' or prop == 'join-throttle' or prop == 'forward':
+                    if len(args) > 0:
+                        self.props[prop] = args.pop(0)
+                    continue
+                if prop == 'op' or prop == 'voice':
+                    usr = args.pop(0)
+                    member = self.find_member(usr)
+                    if not member:
+                        client.dump_numeric('401', [self.name, usr, "No such nick/channel"])
+                        continue
+                    member.props[prop] = mod
+                    continue
+                self.props[prop] = mod
+
+        self.flush_legacy_mode_change(client, before, self.props,
+                                      before_users, {member.client.nickname: member.props for member in self.members})
+
+
+    def flush_legacy_mode_change(self, cli, before, after, before_users, after_users):
+        out = str()
+        args = []
+        mod = 0
+
+        for i in channel_property_items.keys():
+            if before.get(i, False) and not after.get(i, False):
+                if mod == 1:
+                    if i == 'ban' or i == 'quiet' or i == 'invite-exemption' or i == 'exemption':
+                        for j in before.get(i, []):
+                            if j not in after.get(i):
+                                out += channel_property_items[i]
+                                args.append(j)
+                        continue
+                    out += channel_property_items[i]
+                    if before.get(i, False) != True:
+                        args.append(before.get(i))
+                else:
+                    mod = 1
+                    out += '-'
+                    if i == 'ban' or i == 'quiet' or i == 'invite-exemption' or i == 'exemption':
+                        for j in before.get(i, []):
+                            if j not in after.get(i):
+                                out += channel_property_items[i]
+                                args.append(j)
+                        continue
+                    out += channel_property_items[i]
+                    if before.get(i, False) != True:
+                        args.append(before.get(i))
+            elif not before.get(i, False) and after.get(i, False):
+                if mod == 2:
+                    if i == 'ban' or i == 'quiet' or i == 'invite-exemption' or i == 'exemption':
+                        for j in after.get(i):
+                            if j not in before.get(i, []):
+                                out += channel_property_items[i]
+                                args.append(j)
+                        continue
+                    out += channel_property_items[i]
+                    if after.get(i, False) != True:
+                        args.append(after.get(i))
+                else:
+                    mod = 2
+                    out += '+'
+                    if i == 'ban' or i == 'quiet' or i == 'invite-exemption' or i == 'exemption':
+                        for j in after.get(i):
+                            if j not in before.get(i, []):
+                                out += channel_property_items[i]
+                                args.append(j)
+                        continue
+                    out += channel_property_items[i]
+                    if after.get(i, False) != True:
+                        args.append(after.get(i))
+            for nick, flags in before_users.items():
+                if flags.get(i) and not after_users[nick].get(i):
+                    if mod == 1:
+                        out += channel_property_items[i]
+                        args.append(nick)
+                    else:
+                        mod = 1
+                        out += '-'
+                        out += channel_property_items[i]
+                        args.append(nick)
+            for nick, flags in after_users.items():
+                if flags.get(i) and not before_users[nick].get(i):
+                    if mod == 1:
+                        out += channel_property_items[i]
+                        args.append(nick)
+                    else:
+                        mod = 1
+                        out += '+'
+                        out += channel_property_items[i]
+                        args.append(nick)
+
+        msg = RFC1459Message.from_data('MODE', source=cli.hostmask, params=[self.name, out] + args)
+        self.dump_message(msg)
+
+    @property
+    def legacy_modes(self):
+        args = ['+']
+        for i in self.props.keys():
+            if self.props[i] != False and i in channel_property_items \
+                    and not (i == 'ban' or i == 'quiet' or i == 'invite-exemption' or i == 'exemption'):
+                args[0] += channel_property_items[i]
+                if self.props[i] != True:
+                    args.append(self.props[i])
+        return ' '.join(args)
 
     @property
     def classification(self):
@@ -205,6 +373,10 @@ def m_TOPIC(cli, ev_msg):
 
         if not ch.has_member(cli):
             cli.dump_numeric('442', [ch.name, "You're not on that channel"])
+            continue
+
+        if not ch.get_member(cli).props.get('op', False) and ch.props.get('op-topic'):
+            cli.dump_numeric('482', [ch.name, 'You\'re not a channel operator'])
             continue
 
         # handle inquiry

--- a/mammon/core/rfc1459/__init__.py
+++ b/mammon/core/rfc1459/__init__.py
@@ -246,8 +246,33 @@ def m_MODE(cli, ev_msg):
     elif ev_msg['params'][0][0] != '#':
         cli.dump_numeric('502', ["Can't change mode for other users"])
         return
+    else:
+        chanlist = ev_msg['params'][0].split(',')
+        for chan in chanlist:
+            if not validate_chan(chan):
+                cli.dump_numeric('479', [chan, 'Illegal channel name'])
+                return
 
-    # XXX - channels not implemented
+            ch = cli.ctx.chmgr.get(chan, create=False)
+            if not ch:
+                cli.dump_numeric('403', [chan, 'No such channel'])
+                continue
+
+            if not ch.has_member(cli):
+                cli.dump_numeric('442', [ch.name, "You're not on that channel"])
+                continue
+            print(ev_msg)
+            # handle inquiry
+            if len(ev_msg['params']) == 1 or len(ev_msg['params'][1]) < 2:
+                cli.dump_numeric('324', [ch.name, ch.legacy_modes])
+                cli.dump_numeric('329', [ch.name, ch.props_ts])
+                continue
+            if not ch.get_member(cli).props.get('op', False):
+                cli.dump_numeric('482', [ch.name, 'You\'re not a channel operator'])
+                continue
+
+            ch.set_legacy_modes(cli, ev_msg['params'][1], ev_msg['params'][2:])
+            ch.props_ts = cli.ctx.current_ts
 
 @eventmgr_rfc1459.message('ISON', min_params=1)
 def m_ISON(cli, ev_msg):

--- a/mammon/property.py
+++ b/mammon/property.py
@@ -22,7 +22,7 @@ user_property_items = {
     'user:invisible': 'i',
     'user:wallops': 'w',
     'special:oper': 'o',
-    'special:tls': 'Z'
+    'special:tls': 'Z',
 }
 
 user_property_items = CaseInsensitiveDict(**user_property_items)
@@ -33,5 +33,23 @@ member_property_items = {
     'voice': '+',
 }
 
+channel_property_items = {
+    'op': 'o',
+    'voice': 'v',
+    'key': 'k',
+    'ban': 'b',
+    'invite': 'i',
+    'invite-exemption': 'I',
+    'quiet': 'q',
+    'exemption': 'e',
+    'allow-external': 'n',
+    'op-topic': 't',
+    'secret': 's',
+    'moderated': 'm',
+}
+
 member_property_items = CaseInsensitiveDict(**member_property_items)
 member_flag_items = {flag: prop for prop, flag in member_property_items.items()}
+
+channel_property_items = CaseInsensitiveDict(**channel_property_items)
+channel_flag_items = {flag: prop for prop, flag in channel_property_items.items()}

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -151,7 +151,7 @@ Options:
                 print('mammon: error: no parameter provided for --config')
                 exit(1)
         if '--debug' in sys.argv:
-            self.logger.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
+            logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
         if '--nofork' in sys.argv:
             self.nofork = True
 
@@ -163,7 +163,7 @@ Options:
         self.load_modules()
 
     def open_listeners(self):
-        [self.eventloop.create_task(lstn) for lstn in self.listeners]
+        [asyncio.async(lstn) for lstn in self.listeners]
 
     def load_module(self, mod):
         try:


### PR DESCRIPTION
According to [python documentation](https://docs.python.org/3.4/library/logging.html#logging.basicConfig), the correct way to use `.basicConfig` is on the `logging` module you imported, not the initialized logger.

Additionally, it seems like creating a loop using `create_task` is a [bug](https://bugs.python.org/issue22112) and it prevents me from running the ircd, so I've changed that accordingly too.

For channel modes, we now support list-type modes, boolean modes, string-value modes, and channel "rank" modes, and a handful have been implemented.

New users joining empty channels are granted `+o` status and can then set modes and topics. Setting modes dumps out the change in modes correctly and the `/mode #channel` command works.

I've changed a few instances of `'property' in props` to `props.get('property', False)` so the property dictionary for users/channel associations and channels themselves can be set to False and not take effect.

The modes we currently support are listed on line 36 of `mammon/property.py`.
