### PR TITLE
Add MONITOR

### DIFF
--- a/mammon/capability.py
+++ b/mammon/capability.py
@@ -16,7 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from mammon.utility import CaseInsensitiveDict
-from mammon.events import eventmgr_rfc1459
+from mammon.events import eventmgr_core, eventmgr_rfc1459
 from ircreactor.envelope import RFC1459Message
 
 caplist = CaseInsensitiveDict()

--- a/mammon/capability.py
+++ b/mammon/capability.py
@@ -124,10 +124,30 @@ def m_CAP_REQ(cli, ev_msg):
     cli.dump_numeric('CAP', ['ACK', ' '.join(cap_add) + ' -'.join(cap_del) + ' '])
 
     # we accepted the changeset, so apply it
-    for cap in cap_add:
+    info = {
+        'client': cli,
+        'caps': cap_add,
+    }
+    eventmgr_core.dispatch('cap add', info)
+
+    info = {
+        'client': cli,
+        'caps': cap_del,
+    }
+    eventmgr_core.dispatch('cap del', info)
+
+@eventmgr_core.handler('cap add', priority=1)
+def m_cap_add(info):
+    cli = info['client']
+
+    for cap in info['caps']:
         cli.caps[cap] = caplist[cap]
 
-    for cap in cap_del:
+@eventmgr_core.handler('cap del', priority=1)
+def m_cap_del(info):
+    cli = info['client']
+
+    for cap in info['caps']:
         cli.caps.pop(cap)
 
 # XXX: implement CAP ACK for real if it becomes necessary (nothing uses it)

--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -185,8 +185,29 @@ def m_PART(cli, ev_msg):
             cli.dump_numeric('442', [ch.name, "You're not on that channel"])
             return
 
-        ch.dump_message(RFC1459Message.from_data('PART', source=cli.hostmask, params=ev_msg['params']))
-        ch.part(cli)
+        if len(ev_msg['params']) > 1:
+            message = ev_msg['params'][1]
+        else:
+            message = ''
+
+        # part channel
+        info = {
+            'channel': ch,
+            'client': cli,
+            'message': message,
+        }
+        eventmgr_core.dispatch('channel part', info)
+
+@eventmgr_core.handler('channel part', priority=1)
+def m_join_channel(info):
+    ch = info['channel']
+    cli = info['client']
+    message = info['message']
+
+    ctx = get_context()
+
+    ch.dump_message(RFC1459Message.from_data('PART', source=cli.hostmask, params=[ch.name, message]))
+    ch.part(cli)
 
 @eventmgr_rfc1459.message('NAMES', min_params=1)
 def m_NAMES(cli, ev_msg):

--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -16,7 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from ircreactor.envelope import RFC1459Message
-from .utility import validate_chan, CaseInsensitiveDict
+from .utility import validate_chan, CaseInsensitiveDict, CaseInsensitiveList
 from .property import member_property_items
 
 class ChannelManager(object):
@@ -73,7 +73,7 @@ class Channel(object):
         self.topic_setter = str()
         self.topic_ts = 0
         self.props = CaseInsensitiveDict()
-        self.user_set_metadata = []
+        self.user_set_metadata = CaseInsensitiveList()
         self.metadata = CaseInsensitiveDict()
 
     def authorize(self, cli, ev_msg):

--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -18,6 +18,7 @@
 from ircreactor.envelope import RFC1459Message
 from .utility import validate_chan, CaseInsensitiveDict, CaseInsensitiveList
 from .property import member_property_items
+from .server import get_context
 
 class ChannelManager(object):
     def __init__(self, ctx):
@@ -110,10 +111,14 @@ class Channel(object):
             return True
         return self.has_member(client)
 
-    def dump_message(self, msg, exclusion_list=None):
+    def dump_message(self, msg, exclusion_list=None, local_only=True):
         if not exclusion_list:
             exclusion_list = list()
-        [m.client.dump_message(msg) for m in self.members if m.client not in exclusion_list]
+        if local_only:
+            ctx = get_context()
+            [m.client.dump_message(msg) for m in self.members if m.client not in exclusion_list and m.client.servername == ctx.conf.name]
+        else:
+            [m.client.dump_message(msg) for m in self.members if m.client not in exclusion_list]
 
     @property
     def classification(self):
@@ -122,7 +127,7 @@ class Channel(object):
         return '@'
 
 # --- rfc1459 channel management commands ---
-from .events import eventmgr_rfc1459
+from .events import eventmgr_core, eventmgr_rfc1459
 
 @eventmgr_rfc1459.message('JOIN', min_params=1, update_idle=True)
 def m_JOIN(cli, ev_msg):
@@ -138,13 +143,29 @@ def m_JOIN(cli, ev_msg):
         if not ch.authorize(cli, ev_msg):
             continue
 
-        ch.join(cli)
-        ch.dump_message(RFC1459Message.from_data('JOIN', source=cli.hostmask, params=[ch.name]))
+        # join channel
+        info = {
+            'channel': ch,
+            'client': cli,
+        }
+        eventmgr_core.dispatch('channel join', info)
 
-        if ch.topic:
-            cli.handle_side_effect('TOPIC', params=[ch.name])
+@eventmgr_core.handler('channel join', priority=1)
+def m_join_channel(info):
+    ch = info['channel']
+    cli = info['client']
+    ctx = get_context()
 
-        cli.handle_side_effect('NAMES', params=[ch.name])
+    ch.join(cli)
+    ch.dump_message(RFC1459Message.from_data('join', source=cli.hostmask, params=[ch.name]))
+
+    if cli.servername != ctx.conf.name:
+        return
+
+    if ch.topic:
+        cli.handle_side_effect('TOPIC', params=[ch.name])
+
+    cli.handle_side_effect('NAMES', params=[ch.name])
 
 @eventmgr_rfc1459.message('PART', min_params=1, update_idle=True)
 def m_PART(cli, ev_msg):

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -59,6 +59,7 @@ class ClientProtocol(asyncio.Protocol):
         self.user_set_metadata = CaseInsensitiveList()
         self.metadata = CaseInsensitiveDict()
         self.servername = self.ctx.conf.name
+        self.monitoring = CaseInsensitiveList()
 
         self.away_message = str()
         self._role_name = None

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -22,7 +22,7 @@ import copy
 
 from ircreactor.envelope import RFC1459Message
 from .channel import Channel
-from .utility import CaseInsensitiveDict, uniq
+from .utility import CaseInsensitiveDict, CaseInsensitiveList, uniq
 from .property import user_property_items, user_mode_items
 from .server import eventmgr_rfc1459, eventmgr_core, get_context
 from . import __version__
@@ -56,7 +56,7 @@ class ClientProtocol(asyncio.Protocol):
         self.realname = '<unregistered>'
         self.props = CaseInsensitiveDict()
         self.caps = CaseInsensitiveDict()
-        self.user_set_metadata = []
+        self.user_set_metadata = CaseInsensitiveList()
         self.metadata = CaseInsensitiveDict()
         self.servername = self.ctx.conf.name
 

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -317,7 +317,7 @@ class ClientProtocol(asyncio.Protocol):
         msg = RFC1459Message.from_data('MODE', source=self.hostmask, params=[self.nickname, out])
         self.dump_message(msg)
 
-    def sendto_common_peers(self, message, exclude=[], cap=None):
+    def get_common_peers(self, exclude=[], cap=None):
         if cap:
             base = [i.client for m in self.channels for i in m.channel.members if i.client not in exclude and cap in i.client.caps] + [self]
         else:
@@ -325,7 +325,15 @@ class ClientProtocol(asyncio.Protocol):
         peerlist = uniq(base)
         if self in exclude:
             peerlist.remove(self)
+        return peerlist
+
+    def sendto_common_peers(self, message, **kwargs):
+        peerlist = self.get_common_peers(**kwargs)
         [i.dump_message(message) for i in peerlist]
+
+    def numericto_common_peers(self, numeric, params, **kwargs):
+        peerlist = self.get_common_peers(**kwargs)
+        [i.dump_numeric(numeric, params) for i in peerlist]
 
     def dump_isupport(self):
         isupport_tokens = {

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -197,7 +197,11 @@ class ClientProtocol(asyncio.Protocol):
 
     def dump_notice(self, message):
         "Dump a NOTICE to a connected client."
-        msg = RFC1459Message.from_data('NOTICE', source=self.ctx.conf.name, params=[self.nickname, '*** ' + message])
+        self.dump_verb('NOTICE', params=[self.nickname, '*** ' + message])
+
+    def dump_verb(self, verb, params):
+        """Dump a verb to a connected client."""
+        msg = RFC1459Message.from_data(verb, source=self.ctx.conf.name, params=params)
         self.dump_message(msg)
 
     @property

--- a/mammon/config.py
+++ b/mammon/config.py
@@ -22,6 +22,7 @@ import asyncio
 import logging
 from .client import ClientProtocol
 from .roles import Role
+from .utility import CaseInsensitiveList
 
 def load_extended_roles(ctx, k, roles, roles_extending):
     for kk, vv in roles_extending.get(k, {}).items():
@@ -97,6 +98,7 @@ class ConfigHandler(object):
 
         if self.metadata.get('restricted_keys', []) is None:
             self.metadata['restricted_keys'] = []
+        self.metadata['restricted_keys'] = CaseInsensitiveList(self.metadata['restricted_keys'])
 
         # roles
         roles = {}

--- a/mammon/core/ircv3/__init__.py
+++ b/mammon/core/ircv3/__init__.py
@@ -18,3 +18,4 @@
 # - - - BUILTIN IRCV3 EVENTS - - -
 
 from . import metadata
+from . import monitor

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -267,7 +267,7 @@ def dump_metadata_notify(source, target, key, args, monitor_list=None, restricte
         if cli == source or cli == target:
             continue
         if cli.servername == ctx.conf.name:
-            cli.dump_numeric('761', args)
+            cli.dump_verb('METADATA', args)
 
 @eventmgr_core.handler('metadata clear', priority=1)
 def m_metadata_clear(info):
@@ -284,8 +284,9 @@ def m_metadata_clear(info):
     for key, kinfo in keys.items():
         set_key(target, key)
 
+        args = [target_name, key, kinfo['visibility']]
+
         if source.servername == ctx.conf.name:
-            args = [target_name, key, kinfo['visibility']]
             source.dump_numeric('761', args)
 
         # sendto monitoring clients

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -380,6 +380,9 @@ def m_metadata_monitor_chanjoin(info):
     cli = info['client']
     ch = info['channel']
 
+    # we don't check metadata-notify here because they should be auto-subscribed
+    #   for when they enable metadata-notify anyway
+
     client.monitoring.append(ch.name)
 
     for key, visibility in get_visible_keys(cli, ch):

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -300,6 +300,7 @@ def m_metadata_set(info):
     ctx = get_context()
 
     source = info['source']
+    target = info['target']
     key = info['key']
     value = info['value']
 
@@ -307,7 +308,7 @@ def m_metadata_set(info):
     if value:
         args.append(value)
 
-    set_key(info['target'], key, value)
+    set_key(target, key, value)
 
     # if local client, dump numerics
     if source.servername == ctx.conf.name:

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -349,6 +349,9 @@ def m_metadata_set(info):
 
 @eventmgr_core.handler('cap set', priority=1, local_client='client')
 def m_metadata_cap_notify(info):
+    if 'metadata-notify' not in info['caps']:
+        return
+
     cli = info['client']
     for key, visibility in get_visible_keys(cli, cli):
         cli.dump_verb('METADATA', [cli.nickname, key, visibility])
@@ -359,3 +362,16 @@ def m_metadata_cap_notify(info):
             if target:
                 for key, visibility in get_visible_keys(cli, target):
                     cli.dump_verb('METADATA', [target.nickname, key, visibility])
+
+@eventmgr_core.handler('monitor +', priority=1, local_client='client')
+def m_metadata_monitor_target(info):
+    cli = info['client']
+
+    if 'metadata-notify' not in cli.caps:
+        return
+
+    for nickname in info['targets']:
+        target = cli.ctx.clients.get(nickname, None)
+        if target:
+            for key, visibility in get_visible_keys(cli, target):
+                cli.dump_verb('METADATA', [target.nickname, key, visibility])

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -383,7 +383,7 @@ def m_metadata_monitor_chanjoin(info):
     # we don't check metadata-notify here because they should be auto-subscribed
     #   for when they enable metadata-notify anyway
 
-    client.monitoring.append(ch.name)
+    cli.monitoring.append(ch.name)
 
     for key, visibility in get_visible_keys(cli, ch):
         cli.dump_verb('METADATA', [ch.name, key, visibility])

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -387,3 +387,13 @@ def m_metadata_monitor_chanjoin(info):
 
     for key, visibility in get_visible_keys(cli, ch):
         cli.dump_verb('METADATA', [ch.name, key, visibility])
+
+@eventmgr_core.handler('channel part', priority=2)
+def m_metadata_monitor_chanpart(info):
+    cli = info['client']
+    ch = info['channel']
+
+    try:
+        cli.monitoring.remove(ch.name)
+    except ValueError:
+        pass

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -356,12 +356,11 @@ def m_metadata_cap_notify(info):
     for key, visibility in get_visible_keys(cli, cli):
         cli.dump_verb('METADATA', [cli.nickname, key, visibility])
 
-    if hasattr(cli, monitoring):
-        for nickname in cli.monitoring:
-            target = cli.ctx.clients.get(nickname, None)
-            if target:
-                for key, visibility in get_visible_keys(cli, target):
-                    cli.dump_verb('METADATA', [target.nickname, key, visibility])
+    for nickname in cli.monitoring:
+        target = cli.ctx.clients.get(nickname, None)
+        if target:
+            for key, visibility in get_visible_keys(cli, target):
+                cli.dump_verb('METADATA', [target.nickname, key, visibility])
 
 @eventmgr_core.handler('monitor +', priority=1, local_client='client')
 def m_metadata_monitor_target(info):
@@ -375,3 +374,13 @@ def m_metadata_monitor_target(info):
         if target:
             for key, visibility in get_visible_keys(cli, target):
                 cli.dump_verb('METADATA', [target.nickname, key, visibility])
+
+@eventmgr_core.handler('channel join', priority=2)
+def m_metadata_monitor_chanjoin(info):
+    cli = info['client']
+    ch = info['channel']
+
+    client.monitoring.append(ch.name)
+
+    for key, visibility in get_visible_keys(cli, ch):
+        cli.dump_verb('METADATA', [ch.name, key, visibility])

--- a/mammon/core/ircv3/monitor.py
+++ b/mammon/core/ircv3/monitor.py
@@ -17,7 +17,7 @@
 
 from mammon.client import ClientProtocol
 from mammon.server import eventmgr_core, eventmgr_rfc1459, get_context
-from mammon.utility import validate_nick, validate_chan, CaseInsensitiveDict, CaseInsensitiveList
+from mammon.utility import validate_nick, CaseInsensitiveDict, CaseInsensitiveList
 
 monitored = CaseInsensitiveDict()
 
@@ -35,14 +35,14 @@ def m_MONITOR(cli, ev_msg):
 
         limit = cli.ctx.conf.monitor.get('limit', None)
         if command == '+' and limit is not None:
-            if len(cli.monitoring) + len(ev_msg['params'][1].split(',')) > limit:
+            if len([c for c in cli.monitoring if validate_nick(c)]) + len(ev_msg['params'][1].split(',')) > limit:
                 cli.dump_numeric('734', [cli.nickname, str(limit), ev_msg['params'][1], 'Monitor list is full'])
                 return
-        
+
         if command in '-+':
             targets = []
             for target in ev_msg['params'][1].split(','):
-                if not validate_nick(target) and not validate_chan(target):
+                if not validate_nick(target):
                     continue
                 targets.append(target)
 

--- a/mammon/core/ircv3/monitor.py
+++ b/mammon/core/ircv3/monitor.py
@@ -28,10 +28,6 @@ def m_MONITOR(cli, ev_msg):
     command = ev_msg['params'][0].casefold()
 
     if command in valid_metadata_subcommands:
-        # XXX - dumb hack until properties arrives
-        if not hasattr(cli, 'monitoring'):
-            cli.monitoring = []
-
         info = {
             'client': cli,
             'command': command,

--- a/mammon/core/ircv3/monitor.py
+++ b/mammon/core/ircv3/monitor.py
@@ -17,7 +17,7 @@
 
 from mammon.client import ClientProtocol
 from mammon.server import eventmgr_core, eventmgr_rfc1459, get_context
-from mammon.utility import validate_nick, validate_chan, CaseInsensitiveDict
+from mammon.utility import validate_nick, validate_chan, CaseInsensitiveDict, CaseInsensitiveList
 
 monitored = CaseInsensitiveDict()
 

--- a/mammon/core/ircv3/monitor.py
+++ b/mammon/core/ircv3/monitor.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from mammon.client import ClientProtocol
+from mammon.server import eventmgr_core, eventmgr_rfc1459, get_context
+from mammon.utility import validate_nick, validate_chan, CaseInsensitiveDict
+
+monitored = CaseInsensitiveDict()
+
+valid_metadata_subcommands = ('-', '+', 'c', 'l', 's')
+
+@eventmgr_rfc1459.message('MONITOR', min_params=1)
+def m_MONITOR(cli, ev_msg):
+    command = ev_msg['params'][0].casefold()
+
+    if command in valid_metadata_subcommands:
+        # XXX - dumb hack until properties arrives
+        if not hasattr(cli, 'monitoring'):
+            cli.monitoring = []
+
+        info = {
+            'source': cli,
+            'command': command,
+        }
+
+        limit = cli.ctx.conf.monitor.get('limit', None)
+        if command == '+' and limit is not None:
+            if len(cli.monitoring) + len(ev_msg['params'][1].split(',')) > limit:
+                cli.dump_numeric('734', [cli.nickname, str(limit), ev_msg['params'][1], 'Monitor list is full'])
+                return
+        
+        if command in '-+':
+            targets = []
+            for target in ev_msg['params'][1].split(','):
+                if not validate_nick(target) and not validate_chan(target):
+                    continue
+                targets.append(target)
+
+            info['targets'] = targets
+
+        eventmgr_core.dispatch(' '.join(['monitor', command]), info)
+    else:
+        cli.dump_numeric(400, ['MONITOR', command, 'Unknown subcommand'])
+
+@eventmgr_core.handler(('monitor -', 'monitor +'), priority=1)
+def m_monitor_edit(info):
+    for target in info['targets']:
+        if target not in monitored:
+            monitored[target] = []
+
+        if info['command'] == '+':
+            monitored[target].append(info['source'])
+            info['source'].monitoring.append(target)
+
+        elif info['command'] == '-':
+            monitored[target].remove(info['source'])
+            info['source'].monitoring.remove(target)
+
+@eventmgr_core.handler('monitor c', priority=1)
+def m_monitor_clear(info):
+    for target in info['source'].monitoring:
+        monitored[target].remove(info['source'])
+    info['source'].monitoring = []
+
+@eventmgr_core.handler('monitor l', priority=1)
+def m_monitor_list(info):
+    ctx = get_context()
+    client = info['source']
+    if client.servername != ctx.conf.name:
+        return
+
+    client.dump_numeric('732', [info['source'].nickname, ','.join(client.monitoring)])
+    client.dump_numeric('733', [info['source'].nickname])
+
+@eventmgr_core.handler('monitor s', priority=1)
+def m_monitor_status(info):
+    ctx = get_context()
+    client = info['source']
+    if client.servername != ctx.conf.name:
+        return
+
+    online = []
+    offline = []
+
+    for target in client.monitoring:
+        if validate_nick(target):
+            if target in ctx.clients:
+                online.append(target)
+            else:
+                offline.append(target)
+
+    if online:
+        client.dump_numeric('730', [info['source'].nickname, ','.join(online)])
+    if offline:
+        client.dump_numeric('731', [info['source'].nickname, ','.join(offline)])
+
+@eventmgr_core.handler('client connect')
+def m_monitor_handle_connect(info):
+    ctx = get_context()
+    nick = info['client'].nickname
+    for client in monitored.get(nick, []):
+        if client.servername == ctx.conf.name:
+            client.dump_numeric('730', [info['source'].nickname, info['client'].nickname])
+
+@eventmgr_core.handler('client quit')
+def m_monitor_handle_quit(info):
+    ctx = get_context()
+    nick = info['client'].nickname
+    for client in monitored.get(nick, []):
+        if client.servername == ctx.conf.name:
+            client.dump_numeric('731', [info['source'].nickname, info['client'].nickname])

--- a/mammon/events.py
+++ b/mammon/events.py
@@ -37,6 +37,7 @@ class EventManager(EventManagerBase):
         return wrapped_fn
 
     def _handle_checker(self, func, local_client=None):
+        from .server import get_context
         def parent_handler(info, *args):
             if local_client:
                 ctx = get_context()

--- a/mammon/events.py
+++ b/mammon/events.py
@@ -19,7 +19,6 @@ import logging
 from functools import wraps
 
 from ircreactor.events import EventManager as EventManagerBase
-from . import server
 
 class EventManager(EventManagerBase):
     """
@@ -40,7 +39,7 @@ class EventManager(EventManagerBase):
     def _handle_checker(self, func, local_client=None):
         def parent_handler(info, *args):
             if local_client:
-                ctx = server.get_context()
+                ctx = get_context()
                 client = info[local_client]
                 if client.servername != ctx.conf.name:
                     return

--- a/mammon/events.py
+++ b/mammon/events.py
@@ -36,9 +36,12 @@ class EventManager(EventManagerBase):
             return func
         return wrapped_fn
 
-    def handler(self, message, priority=10):
+    def handler(self, messages, priority=10):
+        if not isinstance(messages, (list, tuple)):
+            messages = [messages]
         def parent_fn(func):
-            self.register(message, func, priority=priority)
+            for message in messages:
+                self.register(message, func, priority=priority)
             return func
         return parent_fn
 

--- a/mammon/roles.py
+++ b/mammon/roles.py
@@ -15,6 +15,8 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from mammon.utility import CaseInsensitiveList
+
 default_whois_format = 'is a {role}.'
 default_vowel_whois_format = 'is an {role}.'
 
@@ -42,6 +44,9 @@ class Role:
             if key not in self.metakeys_set:
                 self.metakeys_set.append(key)
         del self.metakeys_access
+
+        self.metakeys_get = CaseInsensitiveList(self.metakeys_get)
+        self.metakeys_set = CaseInsensitiveList(self.metakeys_set)
 
         # automatically choose a/an for whois message
         if self.whois_format is None:

--- a/mammon/utility.py
+++ b/mammon/utility.py
@@ -241,6 +241,10 @@ class CaseInsensitiveList(collections.MutableSequence):
 
         return value in self.__store
 
+    def __add__(self, other):
+        self.extend(other)
+        return self
+
 # fast irc casemapping validation
 # part of mammon, under mammon license.
 import string

--- a/mammon/utility.py
+++ b/mammon/utility.py
@@ -219,7 +219,7 @@ class CaseInsensitiveList(collections.MutableSequence):
         if isinstance(value, str):
             value = value.casefold()
 
-        self.__checkValue(value)
+        self._check_value(value)
         self.__store[key] = value
 
     def __delitem__(self, key):

--- a/mammon/utility.py
+++ b/mammon/utility.py
@@ -257,7 +257,7 @@ nick_allowed_chars_tbl = str.maketrans('', '', nick_allowed_chars)
 first_nick_allowed_chars = string.ascii_letters + special
 
 def validate_nick(nick):
-    if nick[0] not in first_nick_allowed_chars:
+    if len(nick) < 1 or nick[0] not in first_nick_allowed_chars:
         return False
     remainder = nick[1:]
     badchars = remainder.translate(nick_allowed_chars_tbl)
@@ -267,7 +267,7 @@ chan_allowed_chars = string.ascii_letters + string.digits + special + '`~!@#$%^&
 chan_allowed_chars_tbl = str.maketrans('', '', chan_allowed_chars)
 
 def validate_chan(chan_name):
-    if chan_name[0] != '#':
+    if len(chan_name) < 1 or chan_name[0] != '#':
         return False
     badchars = chan_name[1:].translate(chan_allowed_chars_tbl)
     return badchars == ''

--- a/mammon/utility.py
+++ b/mammon/utility.py
@@ -195,6 +195,52 @@ class ExpiringDict(collections.OrderedDict):
     def viewvalues(self):
         raise NotImplementedError()
 
+# just a custom casefolding list, designed for things like lists of keys
+class CaseInsensitiveList(collections.MutableSequence):
+    @staticmethod
+    def _check_value(value):
+        if not isinstance(value, object):
+           raise TypeError()
+
+    def __init__(self, data=None):
+        self.__store = []
+
+        if data:
+            self.extend(data)
+
+    def __getitem__(self, key):
+        # try:except is here so iterating works properly
+        try:
+            return self.__store[key]
+        except KeyError:
+            raise IndexError
+
+    def __setitem__(self, key, value):
+        if isinstance(value, str):
+            value = value.casefold()
+
+        self.__checkValue(value)
+        self.__store[key] = value
+
+    def __delitem__(self, key):
+        del self.__store[key]
+
+    def __len__(self):
+        return len(self.__store)
+
+    def insert(self, key, value):
+        if isinstance(value, str):
+            value = value.casefold()
+
+        self._check_value(value)
+        self.__store.insert(key, value)
+
+    def __contains__(self, value):
+        if isinstance(value, str):
+            value = value.casefold()
+
+        return value in self.__store
+
 # fast irc casemapping validation
 # part of mammon, under mammon license.
 import string

--- a/mammond.yml
+++ b/mammond.yml
@@ -136,6 +136,13 @@ metadata:
     # - spammer_probability
 
 
+# Monitor defines the monitoring users are allowed to do on other users
+monitor:
+  # limit - max number of 'monitors' each target is allowed to have
+  #   comment out to remove limit
+  limit: 20
+
+
 # Operator credentials allow a user to transition from a typical user role
 # to a privileged role.
 opers:


### PR DESCRIPTION
I have not had time to test this extensively (particularly `metadata-notify`), but this PR adds the IRCv3 `MONITOR` command, including `metadata-notify` support (with channel-common metadata notifying as proposed in [ircv3/ircv3-specifications #131](https://github.com/ircv3/ircv3-specifications/pull/131).
