### PR TITLE
add channel modes, fix casing in JOIN message repeated back to the client

### DIFF
--- a/mammon/property.py
+++ b/mammon/property.py
@@ -22,7 +22,7 @@ user_property_items = {
     'user:invisible': 'i',
     'user:wallops': 'w',
     'special:oper': 'o',
-    'special:tls': 'Z'
+    'special:tls': 'Z',
 }
 
 user_property_items = CaseInsensitiveDict(**user_property_items)
@@ -33,5 +33,23 @@ member_property_items = {
     'voice': '+',
 }
 
+channel_property_items = {
+    'op': 'o',
+    'voice': 'v',
+    'key': 'k',
+    'ban': 'b',
+    'invite': 'i',
+    'invite-exemption': 'I',
+    'quiet': 'q',
+    'exemption': 'e',
+    'allow-external': 'n',
+    'op-topic': 't',
+    'secret': 's',
+    'moderated': 'm',
+}
+
 member_property_items = CaseInsensitiveDict(**member_property_items)
 member_flag_items = {flag: prop for prop, flag in member_property_items.items()}
+
+channel_property_items = CaseInsensitiveDict(**channel_property_items)
+channel_flag_items = {flag: prop for prop, flag in channel_property_items.items()}


### PR DESCRIPTION
This PR implements the channel modes in https://github.com/mammon-ircd/mammon/pull/30 but doesn't include `op` and `voice` that we plan to implement differently.

Currently there is no way to set the modes, since it requires the permission `set-modes` which is impossible to grant right now, but once we start working on the access list system we can allow access to changing different modes depending on what permissions the user has.

I've left a few `XXX` comments around in places where permissions are needed for certain modes/features to work correctly, and currently they default to the user not having permission, like disallowing talking completely when the channel has +m, so we can more easily see what needs to be changed when we do have access lists.
