### PR TITLE
Return RPL_WHOISACTUALLY when appropriate, now that we have hostnames

### DIFF
--- a/mammon/core/rfc1459/__init__.py
+++ b/mammon/core/rfc1459/__init__.py
@@ -340,6 +340,8 @@ def m_WHOIS(cli, ev_msg):
         cli.dump_numeric('313', [cli_tg.nickname, cli_tg.role.whois_line])
     if cli_tg.account:
         cli.dump_numeric('330', [cli_tg.nickname, cli_tg.account.name, 'is logged in as'])
+    if (cli.props.get('special:oper') or cli == cli_tg) and cli_tg.hostname != cli_tg.realaddr:
+        cli.dump_numeric('338', [cli_tg.nickname, cli_tg.realaddr, 'actually using host'])
     awaymsg = cli_tg.metadata.get('away', None)
     if awaymsg:
         cli.dump_numeric('301', [cli_tg.nickname, awaymsg])


### PR DESCRIPTION
When an oper whoises someone, or someone whoises themself, if the target user has a hostname set this makes it reply with `RPL_WHOISACTUALLY`, similar to Chary/Hybrid/ircu/etc.
