### PR TITLE
data: Add initial datastore (synchronous)

### DIFF
--- a/mammon/data.py
+++ b/mammon/data.py
@@ -22,9 +22,6 @@ import threading
 from .server import get_context
 
 class DataStore:
-    def __init__(self):
-        ...
-
     def create_or_load(self):
         ctx = get_context()
         self.format = ctx.conf.data['format']

--- a/mammon/data.py
+++ b/mammon/data.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import json
+import os
+import threading
+
+from .server import get_context
+
+class DataStore:
+    def __init__(self):
+        ...
+
+    def create_or_load(self):
+        ctx = get_context()
+        self.format = ctx.conf.data['format']
+
+        if self.format == 'json':
+            import json
+            self._store = {}
+            self._store_lock = threading.Lock()
+
+            self._filename = os.path.abspath(os.path.expanduser(ctx.conf.data['filename']))
+
+            ctx.logger.debug('loading json data store from {}'.format(self._filename))
+
+            if os.path.exists(self._filename):
+                self._store = json.loads(open(self._filename, 'r').read())
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    def save(self):
+        if self.format == 'json':
+            import json
+
+            with open(self._filename, 'w') as store_file:
+                store_file.write(json.dumps(self._store))
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    # single keys
+    def __contains__(self, key):
+        if self.format == 'json':
+            return key in self._store
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    def get(self, key, default=None):
+        if self.format == 'json':
+            return self._store.get(key, default)
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    def put(self, key, value):
+        if self.format == 'json':
+            # make sure we can serialize the given data
+            # so we don't choke later on saving the db out
+            json.dumps(value)
+
+            self._store[key] = value
+
+            return True
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    def delete(self, key):
+        if self.format == 'json':
+            try:
+                with self._store_lock:
+                    del self._store[key]
+            except KeyError:
+                # key is already gone, nothing to do
+                ...
+
+            return True
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    # multiple keys
+    def list_keys(self, prefix=None):
+        """Return all key names. If prefix given, return only keys that start with it."""
+        if self.format == 'json':
+            keys = []
+
+            with self._store_lock:
+                for key in self._store:
+                    if prefix is None or key.startswith(prefix):
+                        keys.append(key)
+
+            return keys
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))
+
+    def delete_keys(self, prefix):
+        """Delete all keys with the given prefix."""
+        if self.format == 'json':
+            with self._store_lock:
+                for key in tuple(self._store):
+                    if key.startswith(prefix):
+                        del self._store[key]
+        else:
+            raise Exception('Data store format [{}] not recognised'.format(self.format))

--- a/mammon/data.py
+++ b/mammon/data.py
@@ -30,7 +30,6 @@ class DataStore:
         self.format = ctx.conf.data['format']
 
         if self.format == 'json':
-            import json
             self._store = {}
             self._store_lock = threading.Lock()
 
@@ -45,8 +44,6 @@ class DataStore:
 
     def save(self):
         if self.format == 'json':
-            import json
-
             with open(self._filename, 'w') as store_file:
                 store_file.write(json.dumps(self._store))
         else:

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -199,6 +199,9 @@ Options:
 
         try:
             self.eventloop.run_forever()
+        except KeyboardInterrupt:
+            # don't throw errors on being ctrl+c'd
+            ...
         except:
             raise
         finally:

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -25,6 +25,7 @@ def get_context():
 
 from . import core
 from .config import ConfigHandler
+from .data import DataStore
 from .hashing import HashHandler
 from .utility import CaseInsensitiveDict, ExpiringDict
 from .channel import ChannelManager
@@ -68,6 +69,9 @@ class ServerContext(object):
 
         self.logger.debug('parsing configuration...')
         self.handle_config()
+
+        # must be done after config
+        self.data = DataStore()
 
         self.logger.debug('init finished...')
 
@@ -189,6 +193,16 @@ Options:
         global running_context
         running_context = self
 
+        self.data.create_or_load()
+
         self.update_ts_callback()
-        self.eventloop.run_forever()
+
+        try:
+            self.eventloop.run_forever()
+        except:
+            raise
+        finally:
+            # always save data
+            self.data.save()
+
         exit(0)

--- a/mammond.yml
+++ b/mammond.yml
@@ -17,6 +17,17 @@ server:
   - "This is mammond's default motd.  You can change it in mammond.yml."
 
 
+# The data object defines the data store parameters
+data:
+
+  ## JSON should only be considered for testing
+  # format - data store type
+  format: "json"
+
+  # filename - data store filename
+  filename: ".mammon.data.json"
+
+
 # The listeners object is a list of listeners.
 listeners:
 - {"host": "0.0.0.0", "port": 6667, "ssl": false}


### PR DESCRIPTION
I have not done much work with key-value data stores before. Maybe something along these lines could work?

This initial thing just uses a simple JSON store, mostly intended just for testing and development. I figure with this sort of API we should be able to pretty simply plug in whatever other backend store we want to support.

Right now, this is using a synchronous API. We could go build another event manager and all on top of it if we really need to. Hopefully we can just `yield` the calls to this and use coroutines if we have asynchronous things we need to communicate with (S2S, etc) later on, though? I tried to look at an async API for this, but it's complicated and yuck.
