### PR TITLE
User account registration and SASL

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -394,6 +394,10 @@ class ClientProtocol(asyncio.Protocol):
             cipher = self.transport.get_extra_info('cipher')
             self.dump_notice('You are connected using {1}-{0}-{2}'.format(*cipher))
 
+        eventmgr_core.dispatch('client registered', {
+            'client': self,
+        })
+
         self.dump_numeric('001', ['Welcome to the ' + self.ctx.conf.network + ' IRC Network, ' + self.hostmask])
         self.dump_numeric('002', ['Your host is ' + self.ctx.conf.name + ', running version mammon-' + str(__version__)])
         self.dump_numeric('003', ['This server was started at ' + self.ctx.startstamp])

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -25,6 +25,7 @@ from .channel import Channel
 from .utility import CaseInsensitiveDict, CaseInsensitiveList, uniq, validate_hostname
 from .property import user_property_items, user_mode_items
 from .server import eventmgr_rfc1459, eventmgr_core, get_context
+from .isupport import get_isupport
 from . import __version__
 
 client_registration_locks = ['NICK', 'USER', 'DNS']
@@ -372,25 +373,13 @@ class ClientProtocol(asyncio.Protocol):
         [i.dump_numeric(numeric, params) for i in peerlist]
 
     def dump_isupport(self):
-        isupport_tokens = {
-            'NETWORK': self.ctx.conf.network,
-            'CASEMAPPING': 'rfc3454',
-            'SAFELIST': True,
-            'METADATA': self.ctx.conf.metadata.get('limit', True),
-            'MONITOR': self.ctx.conf.monitor.get('limit', True),
-            'CHANTYPES': '#',
-            'NICKLEN': self.ctx.conf.limits.get('nick', ''),
-            'CHANNELLEN': self.ctx.conf.limits.get('channel', ''),
-            'TOPICLEN': self.ctx.conf.limits.get('topic', ''),
-            'LINELEN': self.ctx.conf.limits.get('line', ''),
-            'USERLEN': self.ctx.conf.limits.get('user', ''),
-        }
-
         # XXX - split into multiple 005 lines if > 13 tokens
         def format_token(k, v):
             if isinstance(v, bool):
                 return k
             return '{0}={1}'.format(k, v)
+
+        isupport_tokens = get_isupport()
 
         self.dump_numeric('005', [format_token(k, v) for k, v in isupport_tokens.items()] + ['are supported by this server'])
 

--- a/mammon/ext/ircv3/register.py
+++ b/mammon/ext/ircv3/register.py
@@ -30,6 +30,13 @@ def m_server_start(info):
     else:
         callbacks = ''
 
+    if not ctx.hashing.enabled:
+        ctx.logger.info('REG passphrase disabled because hashing is not available')
+        supported_cred_types.remove('passphrase')
+    if len(supported_cred_types) == 0:
+        ctx.logger.info('REG because no mechanisms are available')
+        return
+
     isupport_tokens = get_isupport()
     isupport_tokens['REGCOMMANDS'] = 'CREATE,VERIFY'
     isupport_tokens['REGCALLBACKS'] = callbacks
@@ -65,7 +72,7 @@ def m_REG(cli, ev_msg):
             cred_type = 'passphrase'
             credential = params.pop(0)
         else:
-            # not enough params
+            cli.dump_numeric('461', [ev_msg['verb'], 'Not enough parameters'])
             return
 
         if cred_type not in supported_cred_types:
@@ -97,7 +104,7 @@ def m_reg_create_empty(info):
         'account': info['account'],
         'registered': cli.ctx.current_ts,
         'credentials': {
-            'passphrase': info['credential'],
+            'passphrase': cli.ctx.hashing.encrypt(info['credential']),
         },
     })
 

--- a/mammon/ext/ircv3/register.py
+++ b/mammon/ext/ircv3/register.py
@@ -100,12 +100,12 @@ def m_reg_create_empty(info):
         return
 
     cli.ctx.data.put('account.{}'.format(info['account']), {
-        'source': cli.hostmask,
         'account': info['account'],
-        'registered': cli.ctx.current_ts,
         'credentials': {
             'passphrase': cli.ctx.hashing.encrypt(info['credential']),
         },
+        'registered': cli.ctx.current_ts,
+        'registered_by': cli.hostmask,
     })
 
     cli.dump_numeric('920', params=[info['account'], 'Account created'])

--- a/mammon/ext/ircv3/register.py
+++ b/mammon/ext/ircv3/register.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from mammon.events import eventmgr_core, eventmgr_rfc1459
+from mammon.isupport import get_isupport
+
+supported_cred_types = ['passphrase']
+supported_cb_types = ['*', 'mailto']
+
+@eventmgr_core.handler('server start')
+def m_server_start(info):
+    ctx = info['server']
+
+    if ctx.conf.register['callbacks']:
+        callbacks = ','.join(ctx.conf.register['callbacks'])
+    else:
+        callbacks = ''
+
+    isupport_tokens = get_isupport()
+    isupport_tokens['REGCOMMANDS'] = 'CREATE,VERIFY'
+    isupport_tokens['REGCALLBACKS'] = callbacks
+    isupport_tokens['REGCREDTYPES'] = ','.join(supported_cred_types)
+
+@eventmgr_rfc1459.message('REG', min_params=3)
+def m_REG(cli, ev_msg):
+    params = list(ev_msg['params'])
+    subcmd = params.pop(0).casefold()
+
+    if subcmd == 'create':
+        account = params.pop(0).casefold()
+
+        if 'account.{}'.format(account) in cli.ctx.data:
+            cli.dump_numeric('921', params=[account, 'Account already exists'])
+
+        callback = params.pop(0).casefold()
+        if callback == '*':
+            cb_namespace = '*'
+            callback = None,
+        elif ':' in callback:
+            cb_namespace, callback = callback.split(':', 1)
+        else:
+            cb_namespace = 'mailto'
+
+        if cb_namespace not in supported_cb_types:
+            cli.dump_numeric('929', params=[account, cb_namespace, 'Callback token is invalid'])
+            return
+
+        if len(params) > 1:
+            cred_type, credential = params[:2]
+        elif len(params) == 1:
+            cred_type = 'passphrase'
+            credential = params.pop(0)
+        else:
+            # not enough params
+            return
+
+        if cred_type not in supported_cred_types:
+            cli.dump_numeric('928', params=[account, cred_type, 'Credential type is invalid'])
+            return
+
+        eventmgr_core.dispatch('reg callback {}'.format(cb_namespace), {
+            'source': cli,
+            'account': account,
+            'callback': callback,
+            'cb_namespace': cb_namespace,
+            'cred_type': cred_type,
+            'credential': credential,
+        })
+    else:
+        cli.dump_numeric('400', ['REG', ev_msg['params'][0], 'Unknown subcommand'])
+
+@eventmgr_core.handler('reg callback *')
+def m_reg_create_empty(info):
+    cli = info['source']
+
+    # only allow empty callback when no other callbacks exist
+    if cli.ctx.conf.register['callbacks']:
+        cli.dump_numeric('929', params=[info['account'], '*', 'Callback token is invalid'])
+        return
+
+    cli.ctx.data.put('account.{}'.format(info['account']), {
+        'source': cli.hostmask,
+        'account': info['account'],
+        'registered': cli.ctx.current_ts,
+        'credentials': {
+            'passphrase': info['credential'],
+        },
+    })
+
+    cli.dump_numeric('920', params=[info['account'], 'Account created'])
+    cli.account = info['account']
+    cli.dump_numeric('900', params=[cli.hostmask, info['account'],
+                                    'You are now logged in as {}'.format(info['account'])])
+    cli.dump_numeric('903', params=['Authentication successful'])

--- a/mammon/ext/ircv3/sasl.py
+++ b/mammon/ext/ircv3/sasl.py
@@ -94,6 +94,7 @@ def m_sasl_plain(info):
         passphrase_hash = account_info['credentials']['passphrase']
         if cli.ctx.hashing.verify(passphrase, passphrase_hash):
             cli.account = account
+            cli.sasl = None
             hostmask = cli.hostmask
             if hostmask is None:
                 hostmask = '*'

--- a/mammon/ext/ircv3/sasl.py
+++ b/mammon/ext/ircv3/sasl.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from mammon.events import eventmgr_core, eventmgr_rfc1459
+from mammon.capability import Capability
+
+import base64
+import binascii
+
+valid_mechanisms = ['PLAIN']
+
+cap_sasl = Capability('sasl', value=','.join(valid_mechanisms))
+
+@eventmgr_rfc1459.message('AUTHENTICATE', min_params=1, allow_unregistered=True)
+def m_AUTHENTICATE(cli, ev_msg):
+    if len(ev_msg['params']) == 1 and ev_msg['params'][0] == '*':
+        if getattr(cli, 'sasl', None):
+            cli.dump_numeric('906', params=['SASL authentication aborted'])
+            cli.sasl = None
+        else:
+            cli.dump_numeric('904', params=['SASL authentication failed'])
+        return
+
+    if getattr(cli, 'sasl', None):
+        try:
+            data = base64.b64decode(ev_msg['params'][0])
+        except binascii.Error:
+            cli.dump_numeric('904', params=['SASL authentication failed'])
+            return
+
+        eventmgr_core.dispatch('sasl authenticate {}'.format(cli.sasl.casefold()), {
+            'source': cli,
+            'mechanism': cli.sasl,
+            'data': data,
+        })
+
+    else:
+        mechanism = ev_msg['params'][0].upper()
+        if mechanism in valid_mechanisms:
+            cli.sasl = mechanism
+            cli.dump_verb('AUTHENTICATE', '+')
+        else:
+            cli.dump_numeric('904', params=['SASL authentication failed'])
+            return
+
+@eventmgr_core.handler('client registered')
+def m_sasl_unreglocked(info):
+    cli = info['client']
+    if getattr(cli, 'sasl', None):
+        cli.sasl = None
+        cli.dump_numeric('906', params=['SASL authentication aborted'])
+
+@eventmgr_core.handler('sasl authenticate plain')
+def m_sasl_plain(info):
+    cli = info['source']
+    data = info['data']
+
+    account, authorization_id, passphrase = data.split(b'\x00')
+    account = str(account, 'utf8')
+    passphrase = str(passphrase, 'utf8')
+
+    account_info = cli.ctx.data.get('account.{}'.format(account), None)
+    if account_info and 'passphrase' in account_info['credentials']:
+        if passphrase == account_info['credentials']['passphrase']:
+            cli.account = account
+            cli.dump_numeric('900', params=[cli.hostmask, account, 'You are now logged in as {}'.format(account)])
+            cli.dump_numeric('903', params=['SASL authentication successful'])
+            return
+    cli.dump_numeric('904', params=['SASL authentication failed'])

--- a/mammon/ext/ircv3/sasl.py
+++ b/mammon/ext/ircv3/sasl.py
@@ -89,7 +89,8 @@ def m_sasl_plain(info):
     passphrase = str(passphrase, 'utf8')
 
     account_info = cli.ctx.data.get('account.{}'.format(account), None)
-    if account_info and 'passphrase' in account_info['credentials']:
+    if (account_info and 'passphrase' in account_info['credentials'] and
+            account_info['verified']):
         passphrase_hash = account_info['credentials']['passphrase']
         if cli.ctx.hashing.verify(passphrase, passphrase_hash):
             cli.account = account

--- a/mammon/isupport.py
+++ b/mammon/isupport.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+_isupport_tokens = {
+    'CASEMAPPING': 'rfc3454',
+    'SAFELIST': True,
+    'CHANTYPES': '#',
+}
+
+def get_isupport():
+    global _isupport_tokens
+    return _isupport_tokens

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -30,6 +30,7 @@ from .hashing import HashHandler
 from .utility import CaseInsensitiveDict, ExpiringDict
 from .channel import ChannelManager
 from .capability import caplist
+from .isupport import get_isupport
 
 import logging
 import asyncio
@@ -166,6 +167,16 @@ Options:
         self.open_logs()
         self.load_modules()
 
+        isupport_tokens = get_isupport()
+        isupport_tokens['NETWORK'] = self.conf.network
+        isupport_tokens['METADATA'] = self.conf.metadata.get('limit', True)
+        isupport_tokens['MONITOR'] = self.conf.monitor.get('limit', True)
+        isupport_tokens['NICKLEN'] = self.conf.limits.get('nick', '')
+        isupport_tokens['CHANNELLEN'] = self.conf.limits.get('channel', '')
+        isupport_tokens['TOPICLEN'] = self.conf.limits.get('topic', '')
+        isupport_tokens['LINELEN'] = self.conf.limits.get('line', '')
+        isupport_tokens['USERLEN'] = self.conf.limits.get('user', '')
+
     def open_listeners(self):
         [asyncio.async(lstn) for lstn in self.listeners]
 
@@ -196,6 +207,10 @@ Options:
         self.data.create_or_load()
 
         self.update_ts_callback()
+
+        eventmgr_core.dispatch('server start', {
+            'server': self,
+        })
 
         try:
             self.eventloop.run_forever()

--- a/mammond.yml
+++ b/mammond.yml
@@ -68,8 +68,30 @@ register:
 
   # callbacks - types and details for various callback methods
   callbacks:
-    # no callback methods for now
 
+    # mailto - email using sendmail
+    mailto:
+      # from - address our messages get sent from
+      from: mammon@example.com
+
+      # sendmail - location of the sendmail binary
+      sendmail: /usr/sbin/sendmail
+
+      # verify_message_subject - subject of the verify message
+      verify_message_subject: "{network_name} Account Registration"
+
+      # verify_message - message sent to users to verify their account
+      verify_message: |
+        Hi,
+        
+        You have requested to register the account {account}.
+        
+        Your verification code is {verify_code}
+        
+        Please type "/quote REG VERIFY {verify_code}" to complete registration
+        
+        Thank you,
+        {network_name}
 
 # Roles define the capabilities an oper may have, as well as role-specific
 # metadata.

--- a/mammond.yml
+++ b/mammond.yml
@@ -71,6 +71,11 @@ register:
   verify_timeout:
     days: 5
 
+  # enabled_callbacks - callbacks that we allow
+  enabled_callbacks:
+    # - mailto
+    # - none  # no callback required - we recommend requiring a callout
+
   # callbacks - types and details for various callback methods
   callbacks:
 

--- a/mammond.yml
+++ b/mammond.yml
@@ -74,7 +74,7 @@ register:
   # enabled_callbacks - callbacks that we allow
   enabled_callbacks:
     # - mailto
-    # - none  # no callback required - we recommend requiring a callout
+    # - none  # no verification required, will instantly register successfully
 
   # callbacks - types and details for various callback methods
   callbacks:

--- a/mammond.yml
+++ b/mammond.yml
@@ -63,6 +63,14 @@ limits:
   line: 2048
 
 
+# The register object defines registration information
+register:
+
+  # callbacks - types and details for various callback methods
+  callbacks:
+    # no callback methods for now
+
+
 # Roles define the capabilities an oper may have, as well as role-specific
 # metadata.
 
@@ -209,4 +217,5 @@ extensions:
 - mammon.ext.rfc1459.ident
 - mammon.ext.ircv3.server_time
 - mammon.ext.ircv3.echo_message
+- mammon.ext.ircv3.register
 - mammon.ext.misc.nopost

--- a/mammond.yml
+++ b/mammond.yml
@@ -218,4 +218,5 @@ extensions:
 - mammon.ext.ircv3.server_time
 - mammon.ext.ircv3.echo_message
 - mammon.ext.ircv3.register
+- mammon.ext.ircv3.sasl
 - mammon.ext.misc.nopost

--- a/mammond.yml
+++ b/mammond.yml
@@ -88,7 +88,7 @@ register:
         
         Your verification code is {verify_code}
         
-        Please type "/quote REG VERIFY {verify_code}" to complete registration
+        Please type "/quote REG VERIFY {account} {verify_code}" to complete registration
         
         Thank you,
         {network_name}

--- a/mammond.yml
+++ b/mammond.yml
@@ -66,6 +66,11 @@ limits:
 # The register object defines registration information
 register:
 
+  # verify_timeout - length of time a user has to verify their newly-created
+  # account before it can be re-registered
+  verify_timeout:
+    days: 5
+
   # callbacks - types and details for various callback methods
   callbacks:
 
@@ -86,9 +91,9 @@ register:
         
         You have requested to register the account {account}.
         
-        Your verification code is {verify_code}
+        Your verification code is {auth_code}
         
-        Please type "/quote REG VERIFY {account} {verify_code}" to complete registration
+        Please type "/quote REG VERIFY {account} {auth_code}" to complete registration
         
         Thank you,
         {network_name}


### PR DESCRIPTION
Basic `REG` and `SASL` implementations based off the specs. Supports the `mailto` and `*` (no) callbacks for `REG CREATE`, and the `PLAIN` mechanism for `SASL`.

There's no protections against someone trying to `REG CREATE` spam or something like that at the moment, but I'm not sure if we want to bother worrying about that at this point. We do write verified and unverified `REG CREATE` accounts to the data store, and don't delete the unverified, expired ones right now.

[register.py](https://github.com/DanielOaks/mammon/blob/register-and-verify/mammon/ext/ircv3/register.py#L25) also uses a couple of globals, a bit ugly but it works.

I can squash this if desired.
