### PR TITLE
Add userhost-in-names, extended-join, account-notify

### DIFF
--- a/mammon/capability.py
+++ b/mammon/capability.py
@@ -51,9 +51,11 @@ def m_CAP_LS(cli, ev_msg):
         cli.caps['cap-notify'] = caplist['cap-notify']
 
     l = list()
-    for cap in caplist.values():
+    caps = list(caplist.values())
+    for cap in caps:
         l.append(cap.atom(is_ircv3_2))
-        if len(l) > 8:
+        # only dump continuation line if we have more caps to go
+        if len(l) > 8 and caps.index(cap) + 1 < len(caps):
             cli.dump_numeric('CAP', ['LS', '*', ' '.join(l)])
             l = list()
 

--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -16,6 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from ircreactor.envelope import RFC1459Message
+from .capability import Capability
 from .utility import validate_chan, CaseInsensitiveDict, CaseInsensitiveList
 from .server import get_context
 from .property import member_property_items, channel_property_items, channel_flag_items
@@ -50,6 +51,15 @@ class ChannelMembership(object):
             if self.props.get(prop, False):
                 pstr += flag
         pstr += self.client.nickname
+        return pstr
+
+    @property
+    def hostmask(self):
+        pstr = str()
+        for prop, flag in member_property_items.items():
+            if self.props.get(prop, False):
+                pstr += flag
+        pstr += self.client.hostmask
         return pstr
 
     @property
@@ -352,6 +362,8 @@ def m_join_channel(info):
     ch.dump_message(RFC1459Message.from_data('PART', source=cli.hostmask, params=[ch.name, message]))
     ch.part(cli)
 
+cap_userhost_in_names = Capability('userhost-in-names')
+
 @eventmgr_rfc1459.message('NAMES', min_params=1)
 def m_NAMES(cli, ev_msg):
     chanlist = ev_msg['params'][0].split(',')
@@ -371,7 +383,10 @@ def m_NAMES(cli, ev_msg):
             names_f = lambda x: 'user:invisible' not in x.client.props
 
         # XXX - this may need to be split up if we start enforcing an outbound packet size
-        cli.dump_numeric('353', [ch.classification, ch.name, ' '.join([m.name for m in filter(names_f, ch.members)])])
+        if 'userhost-in-names' in cli.caps:
+            cli.dump_numeric('353', [ch.classification, ch.name, ' '.join([m.hostmask for m in filter(names_f, ch.members)])])
+        else:
+            cli.dump_numeric('353', [ch.classification, ch.name, ' '.join([m.name for m in filter(names_f, ch.members)])])
         cli.dump_numeric('366', [ch.name, 'End of /NAMES list.'])
 
 @eventmgr_rfc1459.message('TOPIC', min_params=1, update_idle=True)

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -232,9 +232,11 @@ class ClientProtocol(asyncio.Protocol):
         "Dump a NOTICE to a connected client."
         self.dump_verb('NOTICE', params=[self.nickname, '*** ' + message])
 
-    def dump_verb(self, verb, params):
+    def dump_verb(self, verb, params, source=None):
         """Dump a verb to a connected client."""
-        msg = RFC1459Message.from_data(verb, source=self.ctx.conf.name, params=params)
+        if source is None:
+            source = self.ctx.conf.name
+        msg = RFC1459Message.from_data(verb, source=source, params=params)
         self.dump_message(msg)
 
     @property
@@ -371,6 +373,12 @@ class ClientProtocol(asyncio.Protocol):
     def numericto_common_peers(self, numeric, params, **kwargs):
         peerlist = self.get_common_peers(**kwargs)
         [i.dump_numeric(numeric, params) for i in peerlist]
+
+    def verbto_common_peers(self, verb, params, source=None, **kwargs):
+        peerlist = self.get_common_peers(**kwargs)
+        if source is None:
+            source = self.ctx.conf.name
+        [i.dump_verb(verb, source=source, params=params) for i in peerlist]
 
     def dump_isupport(self):
         # XXX - split into multiple 005 lines if > 13 tokens

--- a/mammon/ext/ircv3/account_notify.py
+++ b/mammon/ext/ircv3/account_notify.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# mammon - a useless ircd
+#
+# Copyright (c) 2015, William Pitcock <nenolod@dereferenced.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from mammon.server import eventmgr_core
+from mammon.capability import Capability
+
+cap_account_notify = Capability('account-notify')
+
+@eventmgr_core.handler('account change')
+def m_account_notify(info):
+    info['source'].verbto_common_peers('ACCOUNT', source=info['source'].hostmask, params=['*' if info['account'] is None else info['account']], cap='account-notify')

--- a/mammon/ext/ircv3/register.py
+++ b/mammon/ext/ircv3/register.py
@@ -150,6 +150,10 @@ def m_REG(cli, ev_msg):
 
                 cli.dump_numeric('923', [account, 'Account verification successful'])
                 cli.account = account
+                eventmgr_core.dispatch('account change', {
+                    'source': cli,
+                    'account': account,
+                })
                 cli.dump_numeric('900', [cli.hostmask, account,
                                          'You are now logged in as {}'.format(account)])
                 cli.dump_numeric('903', ['Authentication successful'])
@@ -176,6 +180,10 @@ def m_reg_create_empty(info):
 
     cli.dump_numeric('920', [info['account'], 'Account created'])
     cli.account = info['account']
+    eventmgr_core.dispatch('account change', {
+        'source': cli,
+        'account': cli.account,
+    })
     cli.dump_numeric('900', [cli.hostmask, info['account'],
                              'You are now logged in as {}'.format(info['account'])])
     cli.dump_numeric('903', ['Authentication successful'])

--- a/mammon/ext/ircv3/sasl.py
+++ b/mammon/ext/ircv3/sasl.py
@@ -94,6 +94,10 @@ def m_sasl_plain(info):
         passphrase_hash = account_info['credentials']['passphrase']
         if cli.ctx.hashing.verify(passphrase, passphrase_hash):
             cli.account = account
+            eventmgr_core.dispatch('account change', {
+                'source': cli,
+                'account': account,
+            })
             cli.sasl = None
             hostmask = cli.hostmask
             if hostmask is None:

--- a/mammond.yml
+++ b/mammond.yml
@@ -247,6 +247,7 @@ opers:
 extensions:
 - mammon.ext.rfc1459.42
 - mammon.ext.rfc1459.ident
+- mammon.ext.ircv3.account_notify
 - mammon.ext.ircv3.server_time
 - mammon.ext.ircv3.echo_message
 - mammon.ext.ircv3.register


### PR DESCRIPTION
Adds a few caps and fixes an error with `CAP LS` returning incorrect continuation lines and confusing clients.
