### PR TITLE
Add account-tag capability

### DIFF
--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -266,7 +266,7 @@ class Channel(object):
                     if after.get(i, False) != True:
                         args.append(after.get(i))
         if len(out) > 0:
-            msg = RFC1459Message.from_data('MODE', source=cli.hostmask, params=[self.name, out] + args)
+            msg = RFC1459Message.from_data('MODE', source=cli, params=[self.name, out] + args)
             self.dump_message(msg)
 
     @property
@@ -322,8 +322,8 @@ def m_join_channel(info):
     ctx = get_context()
 
     ch.join(cli)
-    ch.dump_message(RFC1459Message.from_data('JOIN', source=cli.hostmask, params=[ch.name]), exclude_cap='extended-join')
-    ch.dump_message(RFC1459Message.from_data('JOIN', source=cli.hostmask, params=[ch.name, '*' if cli.account is None else cli.account, cli.realname]), cap='extended-join')
+    ch.dump_message(RFC1459Message.from_data('JOIN', source=cli, params=[ch.name]), exclude_cap='extended-join')
+    ch.dump_message(RFC1459Message.from_data('JOIN', source=cli, params=[ch.name, '*' if cli.account is None else cli.account, cli.realname]), cap='extended-join')
 
     if cli.servername != ctx.conf.name:
         return
@@ -372,7 +372,7 @@ def m_join_channel(info):
 
     ctx = get_context()
 
-    ch.dump_message(RFC1459Message.from_data('PART', source=cli.hostmask, params=[ch.name, message]))
+    ch.dump_message(RFC1459Message.from_data('PART', source=cli, params=[ch.name, message]))
     ch.part(cli)
 
 cap_userhost_in_names = Capability('userhost-in-names')
@@ -448,7 +448,7 @@ def m_TOPIC(cli, ev_msg):
         ch.topic_ts = cli.ctx.current_ts
 
         # distribute new topic to peers
-        ch.dump_message(RFC1459Message.from_data('TOPIC', source=cli.hostmask, params=[ch.name, ch.topic]))
+        ch.dump_message(RFC1459Message.from_data('TOPIC', source=cli, params=[ch.name, ch.topic]))
 
 # XXX - handle ELIST
 @eventmgr_rfc1459.message('LIST')

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -21,6 +21,7 @@ import socket
 import copy
 
 from ircreactor.envelope import RFC1459Message
+from .capability import Capability
 from .channel import Channel
 from .utility import CaseInsensitiveDict, CaseInsensitiveList, uniq, validate_hostname
 from .property import user_property_items, user_mode_items
@@ -28,6 +29,7 @@ from .server import eventmgr_rfc1459, eventmgr_core, get_context
 from .isupport import get_isupport
 from . import __version__
 
+cap_account_tag = Capability('account-tag')
 client_registration_locks = ['NICK', 'USER', 'DNS']
 
 class ClientHistoryEntry(object):
@@ -199,15 +201,27 @@ class ClientProtocol(asyncio.Protocol):
 
     # handle a mandatory side effect resulting from rfc1459.
     def handle_side_effect(self, msg, params=[]):
-        m = RFC1459Message.from_data(msg, source=self.hostmask, params=params)
+        m = RFC1459Message.from_data(msg, source=self, params=params)
         m.client = self
         self.eventmgr.dispatch(*m.to_event())
+
+    def __deepcopy__(self, memo):
+        # XXX - so dump_message works, we don't actually need to return a deep copy
+        return self
 
     def dump_message(self, m):
         """Dumps an RFC1459 format message to the socket.
         Side effect: we actually operate on a copy of the message, because the message may have different optional
         mutations depending on capabilities and broadcast target."""
         out_m = copy.deepcopy(m)
+
+        if isinstance(out_m.source, ClientProtocol):
+            if 'account-tag' in self.caps:
+                if out_m.source.account is None:
+                    out_m.tags['account'] = '*'
+                else:
+                    out_m.tags['account'] = out_m.source.account
+            out_m.source = out_m.source.hostmask
 
         out_m.client = self
         eventmgr_core.dispatch('outbound message postprocess', out_m)
@@ -268,7 +282,7 @@ class ClientProtocol(asyncio.Protocol):
             'reason': reason,
         })
 
-        m = RFC1459Message.from_data('KILL', source=source.hostmask, params=[self.nickname, reason])
+        m = RFC1459Message.from_data('KILL', source=source, params=[self.nickname, reason])
         self.dump_message(m)
         self.quit('Killed ({source} ({reason}))'.format(source=source.nickname, reason=reason))
 
@@ -278,7 +292,7 @@ class ClientProtocol(asyncio.Protocol):
             'message': message,
         })
 
-        m = RFC1459Message.from_data('QUIT', source=self.hostmask, params=[message])
+        m = RFC1459Message.from_data('QUIT', source=self, params=[message])
         self.sendto_common_peers(m)
         self.exit()
 
@@ -353,7 +367,7 @@ class ClientProtocol(asyncio.Protocol):
                     out += '+'
                     out += user_property_items[i]
 
-        msg = RFC1459Message.from_data('MODE', source=self.hostmask, params=[self.nickname, out])
+        msg = RFC1459Message.from_data('MODE', source=self, params=[self.nickname, out])
         self.dump_message(msg)
 
     def get_common_peers(self, exclude=[], cap=None):

--- a/mammon/core/rfc1459/__init__.py
+++ b/mammon/core/rfc1459/__init__.py
@@ -118,7 +118,7 @@ def m_NICK(cli, ev_msg):
     if new_nickname in cli.ctx.clients:
         cli.dump_numeric('433', [new_nickname, 'Nickname already in use'])
         return
-    msg = RFC1459Message.from_data('NICK', source=cli.hostmask, params=[new_nickname])
+    msg = RFC1459Message.from_data('NICK', source=cli, params=[new_nickname])
     if cli.registered:
         if cli.nickname in cli.ctx.clients:
             cli.ctx.clients.pop(cli.nickname)
@@ -201,12 +201,12 @@ def m_PRIVMSG(cli, ev_msg):
 def m_privmsg_client(info):
     ctx = get_context()
     if ctx.conf.name == info['target'].servername:
-        msg = RFC1459Message.from_data('PRIVMSG', source=info['source'].hostmask, params=[info['target_name'], info['message']])
+        msg = RFC1459Message.from_data('PRIVMSG', source=info['source'], params=[info['target_name'], info['message']])
         info['target'].dump_message(msg)
 
 @eventmgr_core.handler('channel message')
 def m_privmsg_channel(info):
-    msg = RFC1459Message.from_data('PRIVMSG', source=info['source'].hostmask, params=[info['target_name'], info['message']])
+    msg = RFC1459Message.from_data('PRIVMSG', source=info['source'], params=[info['target_name'], info['message']])
     # XXX - when we have s2s, make sure we only dump messages to local clients here or in dump_message
     info['target'].dump_message(msg, exclusion_list=[info['source']])
 
@@ -220,7 +220,7 @@ def m_NOTICE(cli, ev_msg):
             cli_tg = cli.ctx.clients.get(target, None)
             if not cli_tg:
                 continue
-            msg = RFC1459Message.from_data('NOTICE', source=cli.hostmask, params=[cli_tg.nickname, message])
+            msg = RFC1459Message.from_data('NOTICE', source=cli, params=[cli_tg.nickname, message])
             cli_tg.dump_message(msg)
             continue
 
@@ -228,7 +228,7 @@ def m_NOTICE(cli, ev_msg):
         if not ch or not ch.can_send(cli):
             continue
 
-        msg = RFC1459Message.from_data('NOTICE', source=cli.hostmask, params=[ch.name, message])
+        msg = RFC1459Message.from_data('NOTICE', source=cli, params=[ch.name, message])
         ch.dump_message(msg, exclusion_list=[cli])
 
 @eventmgr_rfc1459.message('MOTD')

--- a/mammon/core/rfc1459/away.py
+++ b/mammon/core/rfc1459/away.py
@@ -60,7 +60,7 @@ def m_away_notify(info):
     params = cli.metadata.get('away', None)
     if params:
         params = [params]
-    msg = RFC1459Message.from_data('AWAY', source=cli.hostmask, params=params)
+    msg = RFC1459Message.from_data('AWAY', source=cli, params=params)
     cli.sendto_common_peers(msg, exclude=[cli], cap='away-notify')
 
 @eventmgr_core.handler('client message')

--- a/mammon/ext/ircv3/account_notify.py
+++ b/mammon/ext/ircv3/account_notify.py
@@ -22,4 +22,4 @@ cap_account_notify = Capability('account-notify')
 
 @eventmgr_core.handler('account change')
 def m_account_notify(info):
-    info['source'].verbto_common_peers('ACCOUNT', source=info['source'].hostmask, params=['*' if info['account'] is None else info['account']], cap='account-notify')
+    info['source'].verbto_common_peers('ACCOUNT', source=info['source'], params=['*' if info['account'] is None else info['account']], cap='account-notify')

--- a/mammon/ext/ircv3/echo_message.py
+++ b/mammon/ext/ircv3/echo_message.py
@@ -27,5 +27,5 @@ cap_echo_message = Capability('echo-message')
 def m_privmsg_client(info):
     ctx = get_context()
     if ctx.conf.name == info['source'].servername and 'echo-message' in info['source'].caps:
-        msg = RFC1459Message.from_data('PRIVMSG', source=info['source'].hostmask, params=[info['target_name'], info['message']])
+        msg = RFC1459Message.from_data('PRIVMSG', source=info['source'], params=[info['target_name'], info['message']])
         info['source'].dump_message(msg)


### PR DESCRIPTION
Just adds the `account-tag` capability throughout the server.

We just need to make sure that instead of `source=*.hostmask`, we leave the `.hostmask` off (and pass the ClientProtocol directly as the source) so `dump_message` handles it all properly and adds the right tag. I was thinking about splitting this into an `ext` module, but given how it affects message processing it pretty much needs to be in core.
