### PR TITLE
Handle SIGINT and SIGTERM better, save datastore when exiting

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -50,6 +50,11 @@ class ClientProtocol(asyncio.Protocol):
     def connection_made(self, transport):
         self.ctx = get_context()
 
+        if self.ctx.shutting_down:
+            self.connected = False
+            transport.close()
+            return
+
         self.peername = transport.get_extra_info('peername')
         if self.peername[0][0] == ':':
             pn = list(self.peername)


### PR DESCRIPTION
This lets us properly handle SIGINT and SIGTERM, and always save the data store when we receive those signals.

I'm not too familiar with *nix signals, but this seems to work properly, and it does save the data store in both the cases of `SIGINT` and `SIGTERM` now.

Here's a log of it shutting down from the client's end:

```
local  -> @time=2015-12-10T10:02:42.000Z :mammon.dnt 353 girc = #test girc!~lol@localhost.localdomain
local  -> @time=2015-12-10T10:02:42.000Z :mammon.dnt 366 girc #test :End of /NAMES list.
local  -> @time=2015-12-10T10:02:42.000Z :mammon.dnt 324 girc #test +
local  -> @time=2015-12-10T10:02:42.000Z :mammon.dnt 329 girc #test 1449741762.3427203
local  -> @time=2015-12-10T10:02:42.000Z :mammon.dnt NOTICE girc :*** Server Terminating. Received SIGINT
Connection closed
```
