### PR TITLE
Implement ping timeouts

### DIFF
--- a/mammon/core/rfc1459/__init__.py
+++ b/mammon/core/rfc1459/__init__.py
@@ -143,12 +143,14 @@ def m_PING(cli, ev_msg):
     reply = ev_msg['params'][0] if ev_msg['params'] else cli.ctx.conf.name
     msg = RFC1459Message.from_data('PONG', source=cli.ctx.conf.name, params=[reply])
     cli.dump_message(msg)
+    cli.update_pings()
 
 @eventmgr_rfc1459.message('PONG', min_params=1, allow_unregistered=True)
 def m_PONG(cli, ev_msg):
     if cli.ping_cookie and int(ev_msg['params'][0]) != cli.ping_cookie:
         return
     cli.last_pong = cli.ctx.current_ts
+    cli.update_pings()
 
 @eventmgr_rfc1459.message('INFO')
 def m_INFO(cli, ev_msg):

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -36,6 +36,7 @@ import functools
 import logging
 import asyncio
 import sys
+import datetime
 import time
 import os
 import signal
@@ -179,6 +180,9 @@ Options:
         isupport_tokens['TOPICLEN'] = self.conf.limits.get('topic', '')
         isupport_tokens['LINELEN'] = self.conf.limits.get('line', '')
         isupport_tokens['USERLEN'] = self.conf.limits.get('user', '')
+
+        self.ping_frequency = datetime.timedelta(**self.conf.clients['ping_frequency']).total_seconds()
+        self.ping_timeout = datetime.timedelta(**self.conf.clients['ping_timeout']).total_seconds()
 
     def open_listeners(self):
         [asyncio.async(lstn) for lstn in self.listeners]

--- a/mammond.yml
+++ b/mammond.yml
@@ -17,6 +17,17 @@ server:
   - "This is mammond's default motd.  You can change it in mammond.yml."
 
 
+# The clients object defines client parameters
+clients:
+  # ping_frequency - client ping frequency
+  ping_frequency:
+    minutes: 1
+
+  # ping_timeout - ping timeout length
+  ping_timeout:
+    minutes: 2
+
+
 # The data object defines the data store parameters
 data:
 


### PR DESCRIPTION
Sometimes users can hang and get disconnected without the server receiving a `connection_lost`. This should not happen often, but can now and then. This implements ping timeouts so we disconnect those sorts of connections.

We send the client a `PING` message after `ping_frequency` without activity (anything that trips `update_idle` and receiving `PING`/`PONG` count as activity). We should only have to send `PING`s ourselves when the connection's not very active.

This does raise another question though, do we want to implement a registration timeout? Mostly to stop users from just joining and not doing anything. That one's dirt simple to implement.

**Note:** We could implement this as a module if we want (with an extra event or two dispatched), but figured it probably belonged in core.
