### PR TITLE
Support installing via setup.py

### DIFF
--- a/mammon/server.py
+++ b/mammon/server.py
@@ -165,7 +165,14 @@ Options:
             self.nofork = True
 
     def handle_config(self):
-        self.conf = ConfigHandler(self.config_name, self)
+        try:
+            self.conf = ConfigHandler(self.config_name, self)
+        except FileNotFoundError:
+            import pkg_resources
+            default_config_path = pkg_resources.resource_filename('mammon', 'mammond.yml')
+            self.logger.info('cannot find config file, using default')
+            self.conf = ConfigHandler(default_config_path, self)
+
         self.conf.process()
         self.open_listeners()
         self.open_logs()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from setuptools import setup, find_packages
+
+with open('README.md') as file:
+    long_description = file.read()
+
+setup(
+    name='mammon',
+    version='0.0.0',
+    description='Legacy-free IRCv3.2 server built ontop of ircreactor.',
+    long_description=long_description,
+    author='William Pitcock',
+    author_email='nenolod@dereferenced.org',
+    url='https://github.com/mammon-ircd/mammon',
+    packages=find_packages(),
+    scripts=['mammond'],
+    data_files=[('mammon', ['mammond.yml'])],
+    install_requires=['docopt', 'PyYAML', 'passlib', 'ircreactor', 'ircmatch'],
+    dependency_links=[
+        'git+https://github.com/mammon-ircd/ircreactor.git#egg=ircreactor',
+    ],
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: ISC License (ISCL)',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Communications :: Chat',
+        'Topic :: Communications :: Chat :: Internet Relay Chat',
+    ]
+)


### PR DESCRIPTION
Lets us install mammon via `python3 setup.py install`.

Basically creates a script called `mammond`, and patches our config file retrieval to grab the default installed config file if one doesn't exist in the current directory / where the user specified with `--config`.
