### PR TITLE
Allow us to specify certain messages to be unprefixed, because some clients fall over

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -118,7 +118,7 @@ class ClientProtocol(asyncio.Protocol):
 
     def dump_ping(self):
         self.ping_cookie = int(self.ctx.current_ts)
-        self.dump_verb('PING', params=[str(self.ping_cookie)])
+        self.dump_verb('PING', params=[str(self.ping_cookie)], unprefixed=True)
 
     @property
     def role(self):
@@ -281,9 +281,11 @@ class ClientProtocol(asyncio.Protocol):
         "Dump a NOTICE to a connected client."
         self.dump_verb('NOTICE', params=[self.nickname, '*** ' + message])
 
-    def dump_verb(self, verb, params, source=None):
+    def dump_verb(self, verb, params, source=None, unprefixed=False):
         """Dump a verb to a connected client."""
-        if source is None:
+        # unprefixed is kind of a hack, but some clients fall over when
+        #   prefixes are presented with messages like PING
+        if source is None and not unprefixed:
             source = self.ctx.conf.name
         msg = RFC1459Message.from_data(verb, source=source, params=params)
         self.dump_message(msg)


### PR DESCRIPTION
IRCCloud and HexChat don't respond to prefixed pings, which causes disconnections and such. This is a workaround that just makes us send them without a prefix.

**note:** This may also become an issue when clients request caps like `server-time`, since I'm fairly sure that if they don't handle prefixed messages, these specific messages with tags will make them fall over as well.
