### PR TITLE
ext.ircv3.sasl: make AUTHENTICATE unprefixed so clients that don't expect it to have tags can still understand it (issue #60)

### DIFF
--- a/mammon/ext/ircv3/sasl.py
+++ b/mammon/ext/ircv3/sasl.py
@@ -67,7 +67,7 @@ def m_AUTHENTICATE(cli, ev_msg):
         mechanism = ev_msg['params'][0].upper()
         if mechanism in valid_mechanisms:
             cli.sasl = mechanism
-            cli.dump_verb('AUTHENTICATE', '+')
+            cli.dump_verb('AUTHENTICATE', '+', unprefixed=True)
         else:
             cli.dump_numeric('904', ['SASL authentication failed'])
             return


### PR DESCRIPTION
This "solves" https://github.com/mammon-ircd/mammon/issues/60 in the manner that it will benefit people whose clients don't understand AUTHENTICATE when it is given with tags, however that really is an issue with the clients.

Also similar: https://github.com/mammon-ircd/mammon/pull/61
