### PR TITLE
Dump RPL_NOTOPIC on channel join if it doesn't exist

### DIFF
--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -328,9 +328,7 @@ def m_join_channel(info):
     if cli.servername != ctx.conf.name:
         return
 
-    if ch.topic:
-        cli.handle_side_effect('TOPIC', params=[ch.name])
-
+    cli.handle_side_effect('TOPIC', params=[ch.name])
     cli.handle_side_effect('NAMES', params=[ch.name])
 
 @eventmgr_rfc1459.message('PART', min_params=1, update_idle=True)


### PR DESCRIPTION
This behaviour differs from the RFCs, but I think it makes sense to be explicit about when there's no topic. See also #65 
