### PR TITLE
mammon.core.rfc1459: Prevent pre-registration NICK collisions

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -341,6 +341,9 @@ class ClientProtocol(asyncio.Protocol):
 
         self.connected = False
         self.transport.close()
+        with self.ctx.prereg_nicks_lock:
+            if self.nickname in self.ctx.prereg_nicks:
+                self.ctx.prereg_nicks.remove(self.nickname)
         if not self.registered:
             return
         while self.channels:

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -451,6 +451,9 @@ class ClientProtocol(asyncio.Protocol):
         self.registered = True
         self.ctx.clients[self.nickname] = self
 
+        with self.ctx.prereg_nicks_lock:
+            self.ctx.prereg_nicks.remove(self.nickname)
+
         self.registration_ts = self.ctx.current_ts
         self.update_idle()
 

--- a/mammon/core/rfc1459/__init__.py
+++ b/mammon/core/rfc1459/__init__.py
@@ -115,9 +115,11 @@ def m_NICK(cli, ev_msg):
     if not validate_nick(new_nickname):
         cli.dump_numeric('432', [new_nickname, 'Erroneous nickname'])
         return
-    if new_nickname in cli.ctx.clients:
-        cli.dump_numeric('433', [new_nickname, 'Nickname already in use'])
-        return
+    with cli.ctx.prereg_nicks_lock:
+        if new_nickname in cli.ctx.clients or new_nickname in cli.ctx.prereg_nicks:
+            cli.dump_numeric('433', [new_nickname, 'Nickname already in use'])
+            return
+        cli.ctx.prereg_nicks.append(new_nickname)
     msg = RFC1459Message.from_data('NICK', source=cli, params=[new_nickname])
     if cli.registered:
         if cli.nickname in cli.ctx.clients:

--- a/mammon/server.py
+++ b/mammon/server.py
@@ -27,7 +27,7 @@ from . import core
 from .config import ConfigHandler
 from .data import DataStore
 from .hashing import HashHandler
-from .utility import CaseInsensitiveDict, ExpiringDict
+from .utility import CaseInsensitiveList, CaseInsensitiveDict, ExpiringDict
 from .channel import ChannelManager
 from .capability import caplist
 from .isupport import get_isupport
@@ -41,11 +41,14 @@ import time
 import os
 import signal
 import importlib
+import threading
 from getpass import getpass
 
 class ServerContext(object):
     options = []
     roles = []
+    prereg_nicks_lock = threading.Lock()
+    prereg_nicks = CaseInsensitiveList()
     clients = CaseInsensitiveDict()
     channels = CaseInsensitiveDict()
     listeners = []


### PR DESCRIPTION
This fixes #63, a decently serious issue where two clients can be given the same nick if they both set it before they finish registration.

The locking's just there to prevent possible race conditions, since this seems like it's very undesirable behaviour.
