### PR TITLE
Fix logic of channel display in LIST.

### DIFF
--- a/mammon/channel.py
+++ b/mammon/channel.py
@@ -146,8 +146,8 @@ class Channel(object):
 
     def can_display(self, client):
         if self.props.get('secret', False):
-            return True
-        return self.has_member(client)
+            return self.has_member(client)
+        return True
 
     def dump_message(self, msg, exclusion_list=None, local_only=True,
                      cap=None, exclude_cap=None):


### PR DESCRIPTION
Former behavior was: display if the channel is secret or the user is in it.
New behavior: display if the channel is not secret or the user is in in it.
