### PR TITLE
mammon.capability: Fix CAP LS and CAP LIST cap continuation for 3.1 clients

### DIFF
--- a/mammon/capability.py
+++ b/mammon/capability.py
@@ -46,7 +46,9 @@ class Capability(object):
 Capability('cap-notify')
 
 def m_CAP_LS(cli, ev_msg):
-    is_ircv3_2 = len(ev_msg['params']) > 1 and int(ev_msg['params'][1]) > 301
+    if len(ev_msg['params']) > 1:
+        cli.cap_version = int(ev_msg['params'][1])
+    is_ircv3_2 = len(ev_msg['params']) > 1 and cli.cap_version > 301
     if is_ircv3_2:
         cli.caps['cap-notify'] = caplist['cap-notify']
 
@@ -56,7 +58,10 @@ def m_CAP_LS(cli, ev_msg):
         l.append(cap.atom(is_ircv3_2))
         # only dump continuation line if we have more caps to go
         if len(l) > 8 and caps.index(cap) + 1 < len(caps):
-            cli.dump_numeric('CAP', ['LS', '*', ' '.join(l)])
+            args = ['LS']
+            if is_ircv3_2:
+                args.append('*')
+            cli.dump_numeric('CAP', args + [' '.join(l)])
             l = list()
 
     if l:
@@ -67,7 +72,10 @@ def m_CAP_LIST(cli, ev_msg):
     for cap in cli.caps.values():
         l.append(cap.name)
         if len(l) > 8:
-            cli.dump_numeric('CAP', ['LIST', '*', ' '.join(l)])
+            args = ['LIST']
+            if cli.cap_version > 301:
+                args.append('*')
+            cli.dump_numeric('CAP', args + [' '.join(l)])
             l = list()
 
     if l:

--- a/mammon/client.py
+++ b/mammon/client.py
@@ -72,6 +72,7 @@ class ClientProtocol(asyncio.Protocol):
         self.realname = '<unregistered>'
         self.props = CaseInsensitiveDict()
         self.caps = CaseInsensitiveDict()
+        self.cap_version = 301
         self.user_set_metadata = CaseInsensitiveList()
         self.metadata = CaseInsensitiveDict()
         self.servername = self.ctx.conf.name


### PR DESCRIPTION
Clients like weechat don't support 3.2. We were sending `CAP LS`/`LIST` continuation lines as described in the [3.2 spec](http://ircv3.net/specs/core/capability-negotiation-3.2.html#multiline-replies-to-cap-ls-and-cap-list) which was tripping them up so they couldn't do SASL, etc.

This fixes that so we present multiple standard 3.1 lines to them instead.
