### PR TITLE
Fix SASL PLAIN auth if authzid is missing.

### DIFF
--- a/mammon/ext/ircv3/sasl.py
+++ b/mammon/ext/ircv3/sasl.py
@@ -84,13 +84,17 @@ def m_sasl_plain(info):
     cli = info['source']
     data = info['data']
 
-    account, authorization_id, passphrase = data.split(b'\x00')
+    authorization_id, account, passphrase = data.split(b'\x00')
     account = str(account, 'utf8')
     passphrase = str(passphrase, 'utf8')
+    authorization_id = str(authorization_id, 'utf8')
+
+    # Derive authorization_id from account name
+    authorization_id = authorization_id or account
 
     account_info = cli.ctx.data.get('account.{}'.format(account), None)
     if (account_info and 'passphrase' in account_info['credentials'] and
-            account_info['verified']):
+            account_info['verified'] and authorization_id == account):
         passphrase_hash = account_info['credentials']['passphrase']
         if cli.ctx.hashing.verify(passphrase, passphrase_hash):
             cli.account = account


### PR DESCRIPTION
The parser swapped account and authorization id, which led to use
the authorization id as account name.

Additionally, derives the authorization id from the account name
if it is not provided, as requested by the PLAIN mechanism.

[RFC 4616](https://tools.ietf.org/html/rfc4616#section-2):

> message   = [authzid] UTF8NUL authcid UTF8NUL passwd
> 
> […]
> 
> Upon receipt of the message, the server will verify the presented (in
> the message) authentication identity (authcid) and password (passwd)
> with the system authentication database, and it will verify that the
> authentication credentials permit the client to act as the (presented
> or derived) authorization identity (authzid).  If both steps succeed,
> the user is authenticated.
> 
> […]
> 
> When no authorization identity is provided, the server derives an
> authorization identity from the prepared representation of the
> provided authentication identity string.  This ensures that the
> derivation of different representations of the authentication
> identity produces the same authorization identity.
