### PR TITLE
Use a proper set for storing monitored users.

### DIFF
--- a/mammon/client.py
+++ b/mammon/client.py
@@ -24,7 +24,7 @@ import functools
 from ircreactor.envelope import RFC1459Message
 from .capability import Capability
 from .channel import Channel
-from .utility import CaseInsensitiveDict, CaseInsensitiveList, uniq, validate_hostname
+from .utility import CaseInsensitiveDict, CaseInsensitiveList, CaseInsensitiveSet, uniq, validate_hostname
 from .property import user_property_items, user_mode_items
 from .server import eventmgr_rfc1459, eventmgr_core, get_context
 from .isupport import get_isupport
@@ -76,7 +76,7 @@ class ClientProtocol(asyncio.Protocol):
         self.user_set_metadata = CaseInsensitiveList()
         self.metadata = CaseInsensitiveDict()
         self.servername = self.ctx.conf.name
-        self.monitoring = CaseInsensitiveList()
+        self.monitoring = CaseInsensitiveSet()
 
         self.away_message = str()
         self._role_name = None

--- a/mammon/core/ircv3/metadata.py
+++ b/mammon/core/ircv3/metadata.py
@@ -383,7 +383,7 @@ def m_metadata_monitor_chanjoin(info):
     # we don't check metadata-notify here because they should be auto-subscribed
     #   for when they enable metadata-notify anyway
 
-    cli.monitoring.append(ch.name)
+    cli.monitoring.add(ch.name)
 
     for key, visibility in get_visible_keys(cli, ch):
         cli.dump_verb('METADATA', [ch.name, key, visibility])
@@ -393,7 +393,4 @@ def m_metadata_monitor_chanpart(info):
     cli = info['client']
     ch = info['channel']
 
-    try:
-        cli.monitoring.remove(ch.name)
-    except ValueError:
-        pass
+    cli.monitoring.discard(ch.name)

--- a/mammon/core/ircv3/monitor.py
+++ b/mammon/core/ircv3/monitor.py
@@ -61,13 +61,11 @@ def m_monitor_edit(info):
 
     for target in info['targets']:
         if target not in monitored:
-            monitored[target] = []
+            monitored[target] = set()
 
         if info['command'] == '+':
-            if cli not in monitored[target]:
-                monitored[target].append(cli)
-            if target not in cli.monitoring:
-                cli.monitoring.append(target)
+            monitored[target].add(cli)
+            cli.monitoring.add(target)
 
             if target in ctx.clients:
                 online.append(target)
@@ -75,14 +73,8 @@ def m_monitor_edit(info):
                 offline.append(target)
 
         elif info['command'] == '-':
-            try:
-                monitored[target].remove(cli)
-            except ValueError:
-                pass
-            try:
-                cli.monitoring.remove(target)
-            except ValueError:
-                pass
+            monitored[target].discard(cli)
+            cli.monitoring.discard(target)
 
     if info['command'] == '+':
         if online:

--- a/mammon/utility.py
+++ b/mammon/utility.py
@@ -245,6 +245,43 @@ class CaseInsensitiveList(collections.MutableSequence):
         self.extend(other)
         return self
 
+class CaseInsensitiveSet(collections.MutableSet):
+    @staticmethod
+    def _check_value(value):
+        if not isinstance(value, object):
+           raise TypeError()
+
+    def __init__(self, data=None):
+        self.__store = set()
+
+        if data:
+            self.update(data)
+
+    def __len__(self):
+        return len(self.__store)
+
+    def add(self, value):
+        if isinstance(value, str):
+            value = value.casefold()
+
+        self._check_value(value)
+        self.__store.add(value)
+
+    def discard(self, value):
+        if isinstance(value, str):
+            value = value.casefold()
+
+        self.__store.discard(value)
+
+    def __contains__(self, value):
+        if isinstance(value, str):
+            value = value.casefold()
+
+        return value in self.__store
+
+    def __iter__(self):
+        return iter(self.__store)
+
 import string
 hostname_allowed_chars = string.ascii_letters + string.digits + '-'
 hostname_allowed_chars_tbl = str.maketrans('', '', hostname_allowed_chars)


### PR DESCRIPTION
The old behavior was to emulate sets by not adding (resp. removing)
items to (resp. from) the list if they were (resp. were not) already
in the list.
