### PR TITLE
Disallow username changing and USER after registration

### DIFF
--- a/mammon/core/rfc1459/__init__.py
+++ b/mammon/core/rfc1459/__init__.py
@@ -129,12 +129,17 @@ def m_NICK(cli, ev_msg):
 
 @eventmgr_rfc1459.message('USER', min_params=4, allow_unregistered=True)
 def m_USER(cli, ev_msg):
-    new_username = ev_msg['params'][0]
-    userlen = cli.ctx.conf.limits.get('user', None)
-    if userlen and len(new_username) > userlen:
-        new_username = new_username[:userlen]
+    if cli.registered:
+        cli.dump_numeric('462', ['You may not reregister'])
+        return
+    # don't allow user to override ident-discovered usernames
+    if not cli.username:
+        new_username = ev_msg['params'][0]
+        userlen = cli.ctx.conf.limits.get('user', None)
+        if userlen and len(new_username) > userlen:
+            new_username = new_username[:userlen]
+        cli.username = '~' + new_username
     new_realname = ev_msg['params'][3]
-    cli.username = '~' + new_username
     cli.realname = new_realname
     cli.release_registration_lock('USER')
 


### PR DESCRIPTION
By default, we accept the `USER` command at any time and change the username and realname. This lets clients change their username after registration, and after ident lookup, which is bad.

For instance, from an IRCCloud connection (where I manually sent a new USER line with /quote):

```
17:01:33 --> testcloud-dan (uid127614@id-127614.brockwell.irccloud.com) has joined #test  
17:03:30 <-- testcloud-dan (~a@id-127614.brockwell.irccloud.com) has left #test (Cycling)
17:03:30 --> testcloud-dan (~a@id-127614.brockwell.irccloud.com) has joined #test
```

We just disallow users from changing their username at all after we get one (either from ident or from an earlier `USER` line). Chary and such seem to create a flag specifically to check whether or not an ident lookup has been successful, and set the username after making sure they haven't set one specifically from a successful ident lookup. I don't think we need to go that far, since multiple `USER` lines before registration should be very uncommon and ident is an external module anyway.
